### PR TITLE
feat: improve component event handler type

### DIFF
--- a/.changeset/clean-taxis-rule.md
+++ b/.changeset/clean-taxis-rule.md
@@ -1,0 +1,5 @@
+---
+"svelte-eslint-parser": minor
+---
+
+feat: improve component event handler type

--- a/package.json
+++ b/package.json
@@ -98,7 +98,9 @@
     "semver": "^7.3.5",
     "string-replace-loader": "^3.0.3",
     "svelte": "^3.57.0",
+    "svelte2tsx": "^0.6.11",
     "typescript": "~5.0.0",
+    "typescript-eslint-parser-for-extra-files": "^0.3.0",
     "vue-eslint-parser": "^9.0.0"
   },
   "publishConfig": {

--- a/src/parser/converts/attr.ts
+++ b/src/parser/converts/attr.ts
@@ -351,7 +351,7 @@ function buildEventHandlerType(
     extends: `infer EVT`,
     true: conditional({
       check: `EVT`,
-      extends: keyof(`HTMLElementEventMap`),
+      extends: `keyof HTMLElementEventMap`,
       true: `HTMLElementEventMap[EVT]`,
       false: `CustomEvent<any>`,
     }),
@@ -376,7 +376,7 @@ function buildEventHandlerType(
         extends: `infer EVT`,
         true: conditional({
           check: `EVT`,
-          extends: keyof(componentEventsType),
+          extends: `keyof ${componentEventsType}`,
           true: `${componentEventsType}[EVT]`,
           false: `CustomEvent<any>`,
         }),
@@ -395,13 +395,13 @@ function buildEventHandlerType(
     extends: "infer EL",
     true: conditional({
       check: `EL`,
-      extends: keyof(`${svelteHTMLElementsType}`),
+      extends: `keyof ${svelteHTMLElementsType}`,
       true: conditional({
         check: `'${attrName}'`,
         extends: "infer ATTR",
         true: conditional({
           check: `ATTR`,
-          extends: keyof(`${svelteHTMLElementsType}[EL]`),
+          extends: `keyof ${svelteHTMLElementsType}[EL]`,
           true: `${svelteHTMLElementsType}[EL][ATTR]`,
           false: nativeEventHandlerType,
         }),
@@ -411,11 +411,6 @@ function buildEventHandlerType(
     }),
     false: `never`,
   });
-
-  /** Generate `keyof T` type. */
-  function keyof(type: string) {
-    return `keyof ${type}`;
-  }
 
   /** Generate `C extends E ? T : F` type. */
   function conditional(types: {

--- a/src/parser/converts/attr.ts
+++ b/src/parser/converts/attr.ts
@@ -346,52 +346,86 @@ function buildEventHandlerType(
   elementName: string,
   eventName: string
 ) {
-  const nativeEventHandlerType = [
-    `(e:`,
-    /**/ `'${eventName}' extends infer EVT`,
-    /**/ /**/ `?EVT extends keyof HTMLElementEventMap`,
-    /**/ /**/ /**/ `?HTMLElementEventMap[EVT]`,
-    /**/ /**/ /**/ `:CustomEvent<any>`,
-    /**/ /**/ `:never`,
-    `)=>void`,
-  ].join("");
+  const nativeEventHandlerType = `(e:${conditional({
+    check: `'${eventName}'`,
+    extends: `infer EVT`,
+    true: conditional({
+      check: `EVT`,
+      extends: keyof(`HTMLElementEventMap`),
+      true: `HTMLElementEventMap[EVT]`,
+      false: `CustomEvent<any>`,
+    }),
+    false: `never`,
+  })})=>void`;
   if (element.type !== "SvelteElement") {
     return nativeEventHandlerType;
   }
   if (element.kind === "component") {
-    // `@typescript-eslint/parser` currently cannot parse `*.svelte` import types correctly.
-    // So if we try to do a correct type parsing, it's argument type will be `any`.
-    // A workaround is to inject the type directly, as `CustomEvent<any>` is better than `any`.
-
-    // const componentEvents = `import('svelte').ComponentEvents<${elementName}>`;
-    // return `(e:'${eventName}' extends keyof ${componentEvents}?${componentEvents}['${eventName}']:CustomEvent<any>)=>void`;
-
-    return `(e:CustomEvent<any>)=>void`;
+    const componentEventsType = `import('svelte').ComponentEvents<${elementName}>`;
+    return `(e:${conditional({
+      check: `0`,
+      extends: `(1 & ${componentEventsType})`,
+      // `componentEventsType` is `any`
+      //   `@typescript-eslint/parser` currently cannot parse `*.svelte` import types correctly.
+      //   So if we try to do a correct type parsing, it's argument type will be `any`.
+      //   A workaround is to inject the type directly, as `CustomEvent<any>` is better than `any`.
+      true: `CustomEvent<any>`,
+      // `componentEventsType` has an exact type.
+      false: conditional({
+        check: `'${eventName}'`,
+        extends: `infer EVT`,
+        true: conditional({
+          check: `EVT`,
+          extends: keyof(componentEventsType),
+          true: `${componentEventsType}[EVT]`,
+          false: `CustomEvent<any>`,
+        }),
+        false: `never`,
+      }),
+    })})=>void`;
   }
   if (element.kind === "special") {
     if (elementName === "svelte:component") return `(e:CustomEvent<any>)=>void`;
     return nativeEventHandlerType;
   }
   const attrName = `on:${eventName}`;
-  const importSvelteHTMLElements =
-    "import('svelte/elements').SvelteHTMLElements";
-  return [
-    `'${elementName}' extends infer EL`,
-    /**/ `?(`,
-    /**/ /**/ `EL extends keyof ${importSvelteHTMLElements}`,
-    /**/ /**/ `?(`,
-    /**/ /**/ /**/ `'${attrName}' extends infer ATTR`,
-    /**/ /**/ /**/ `?(`,
-    /**/ /**/ /**/ /**/ `ATTR extends keyof ${importSvelteHTMLElements}[EL]`,
-    /**/ /**/ /**/ /**/ /**/ `?${importSvelteHTMLElements}[EL][ATTR]`,
-    /**/ /**/ /**/ /**/ /**/ `:${nativeEventHandlerType}`,
-    /**/ /**/ /**/ `)`,
-    /**/ /**/ /**/ `:never`,
-    /**/ /**/ `)`,
-    /**/ /**/ `:${nativeEventHandlerType}`,
-    /**/ `)`,
-    /**/ `:never`,
-  ].join("");
+  const svelteHTMLElementsType = "import('svelte/elements').SvelteHTMLElements";
+  return conditional({
+    check: `'${elementName}'`,
+    extends: "infer EL",
+    true: conditional({
+      check: `EL`,
+      extends: keyof(`${svelteHTMLElementsType}`),
+      true: conditional({
+        check: `'${attrName}'`,
+        extends: "infer ATTR",
+        true: conditional({
+          check: `ATTR`,
+          extends: keyof(`${svelteHTMLElementsType}[EL]`),
+          true: `${svelteHTMLElementsType}[EL][ATTR]`,
+          false: nativeEventHandlerType,
+        }),
+        false: `never`,
+      }),
+      false: nativeEventHandlerType,
+    }),
+    false: `never`,
+  });
+
+  /** Generate `keyof T` type. */
+  function keyof(type: string) {
+    return `keyof ${type}`;
+  }
+
+  /** Generate `C extends E ? T : F` type. */
+  function conditional(types: {
+    check: string;
+    extends: string;
+    true: string;
+    false: string;
+  }) {
+    return `${types.check} extends ${types.extends}?(${types.true}):(${types.false})`;
+  }
 }
 
 /** Convert for Class Directive */

--- a/tests/fixtures/integrations/parser-object-tests/ts-multiple-parser-setup.ts
+++ b/tests/fixtures/integrations/parser-object-tests/ts-multiple-parser-setup.ts
@@ -1,14 +1,11 @@
 /* eslint eslint-comments/require-description: 0, @typescript-eslint/explicit-module-boundary-types: 0 */
-import { BASIC_PARSER_OPTIONS } from "../../../src/parser/test-utils";
+import { generateParserOptions } from "../../../src/parser/test-utils";
 import * as ts from "@typescript-eslint/parser";
 
 export function getConfig() {
   return {
     parser: "svelte-eslint-parser",
-    parserOptions: {
-      ...BASIC_PARSER_OPTIONS,
-      parser: { ts },
-    },
+    parserOptions: generateParserOptions({ parser: { ts } }),
     env: {
       browser: true,
       es2021: true,

--- a/tests/fixtures/integrations/parser-object-tests/ts-single-parser-setup.ts
+++ b/tests/fixtures/integrations/parser-object-tests/ts-single-parser-setup.ts
@@ -1,14 +1,11 @@
 /* eslint eslint-comments/require-description: 0, @typescript-eslint/explicit-module-boundary-types: 0 */
-import { BASIC_PARSER_OPTIONS } from "../../../src/parser/test-utils";
+import { generateParserOptions } from "../../../src/parser/test-utils";
 import * as parser from "@typescript-eslint/parser";
 
 export function getConfig() {
   return {
     parser: "svelte-eslint-parser",
-    parserOptions: {
-      ...BASIC_PARSER_OPTIONS,
-      parser,
-    },
+    parserOptions: generateParserOptions({ parser }),
     env: {
       browser: true,
       es2021: true,

--- a/tests/fixtures/integrations/type-info-tests/await-setup.ts
+++ b/tests/fixtures/integrations/type-info-tests/await-setup.ts
@@ -1,6 +1,6 @@
 /* eslint eslint-comments/require-description: 0, @typescript-eslint/explicit-module-boundary-types: 0 */
 import type { Linter } from "eslint";
-import { BASIC_PARSER_OPTIONS } from "../../../src/parser/test-utils";
+import { generateParserOptions } from "../../../src/parser/test-utils";
 import { rules } from "@typescript-eslint/eslint-plugin";
 export function setupLinter(linter: Linter) {
   linter.defineRule(
@@ -12,7 +12,7 @@ export function setupLinter(linter: Linter) {
 export function getConfig() {
   return {
     parser: "svelte-eslint-parser",
-    parserOptions: BASIC_PARSER_OPTIONS,
+    parserOptions: generateParserOptions(),
     rules: {
       "@typescript-eslint/no-unsafe-call": "error",
     },

--- a/tests/fixtures/integrations/type-info-tests/i18n-setup.ts
+++ b/tests/fixtures/integrations/type-info-tests/i18n-setup.ts
@@ -1,6 +1,6 @@
 /* eslint eslint-comments/require-description: 0, @typescript-eslint/explicit-module-boundary-types: 0 */
 import type { Linter } from "eslint";
-import { BASIC_PARSER_OPTIONS } from "../../../src/parser/test-utils";
+import { generateParserOptions } from "../../../src/parser/test-utils";
 import { rules } from "@typescript-eslint/eslint-plugin";
 export function setupLinter(linter: Linter) {
   linter.defineRule(
@@ -12,7 +12,7 @@ export function setupLinter(linter: Linter) {
 export function getConfig() {
   return {
     parser: "svelte-eslint-parser",
-    parserOptions: BASIC_PARSER_OPTIONS,
+    parserOptions: generateParserOptions(),
     rules: {
       "@typescript-eslint/no-unsafe-call": "error",
     },

--- a/tests/fixtures/integrations/type-info-tests/issue226-setup.ts
+++ b/tests/fixtures/integrations/type-info-tests/issue226-setup.ts
@@ -12,7 +12,7 @@ export function setupLinter(linter: Linter) {
 export function getConfig() {
   return {
     parser: "svelte-eslint-parser",
-    parserOptions: generateParserOptions,
+    parserOptions: generateParserOptions(),
     rules: {
       "@typescript-eslint/no-unsafe-argument": "error",
     },

--- a/tests/fixtures/integrations/type-info-tests/issue226-setup.ts
+++ b/tests/fixtures/integrations/type-info-tests/issue226-setup.ts
@@ -1,6 +1,6 @@
 /* eslint eslint-comments/require-description: 0, @typescript-eslint/explicit-module-boundary-types: 0 */
 import type { Linter } from "eslint";
-import { BASIC_PARSER_OPTIONS } from "../../../src/parser/test-utils";
+import { generateParserOptions } from "../../../src/parser/test-utils";
 import { rules } from "@typescript-eslint/eslint-plugin";
 export function setupLinter(linter: Linter) {
   linter.defineRule(
@@ -12,7 +12,7 @@ export function setupLinter(linter: Linter) {
 export function getConfig() {
   return {
     parser: "svelte-eslint-parser",
-    parserOptions: BASIC_PARSER_OPTIONS,
+    parserOptions: generateParserOptions,
     rules: {
       "@typescript-eslint/no-unsafe-argument": "error",
     },

--- a/tests/fixtures/integrations/type-info-tests/no-unnecessary-condition01-setup.ts
+++ b/tests/fixtures/integrations/type-info-tests/no-unnecessary-condition01-setup.ts
@@ -1,6 +1,6 @@
 /* eslint eslint-comments/require-description: 0, @typescript-eslint/explicit-module-boundary-types: 0 */
 import type { Linter } from "eslint";
-import { BASIC_PARSER_OPTIONS } from "../../../src/parser/test-utils";
+import { generateParserOptions } from "../../../src/parser/test-utils";
 import { rules } from "@typescript-eslint/eslint-plugin";
 export function setupLinter(linter: Linter) {
   linter.defineRule(
@@ -12,7 +12,7 @@ export function setupLinter(linter: Linter) {
 export function getConfig() {
   return {
     parser: "svelte-eslint-parser",
-    parserOptions: BASIC_PARSER_OPTIONS,
+    parserOptions: generateParserOptions(),
     rules: {
       "@typescript-eslint/no-unnecessary-condition": "error",
     },

--- a/tests/fixtures/integrations/type-info-tests/plugin-issue254-setup.ts
+++ b/tests/fixtures/integrations/type-info-tests/plugin-issue254-setup.ts
@@ -1,6 +1,6 @@
 /* eslint eslint-comments/require-description: 0, @typescript-eslint/explicit-module-boundary-types: 0 */
 import type { Linter } from "eslint";
-import { BASIC_PARSER_OPTIONS } from "../../../src/parser/test-utils";
+import { generateParserOptions } from "../../../src/parser/test-utils";
 import { rules } from "@typescript-eslint/eslint-plugin";
 export function setupLinter(linter: Linter) {
   linter.defineRule(
@@ -12,7 +12,7 @@ export function setupLinter(linter: Linter) {
 export function getConfig() {
   return {
     parser: "svelte-eslint-parser",
-    parserOptions: BASIC_PARSER_OPTIONS,
+    parserOptions: generateParserOptions(),
     rules: {
       "@typescript-eslint/no-unnecessary-condition": "error",
     },

--- a/tests/fixtures/integrations/type-info-tests/reactive-setup.ts
+++ b/tests/fixtures/integrations/type-info-tests/reactive-setup.ts
@@ -1,6 +1,6 @@
 /* eslint eslint-comments/require-description: 0, @typescript-eslint/explicit-module-boundary-types: 0 */
 import type { Linter } from "eslint";
-import { BASIC_PARSER_OPTIONS } from "../../../src/parser/test-utils";
+import { generateParserOptions } from "../../../src/parser/test-utils";
 import { rules } from "@typescript-eslint/eslint-plugin";
 export function setupLinter(linter: Linter) {
   linter.defineRule(
@@ -28,7 +28,7 @@ export function setupLinter(linter: Linter) {
 export function getConfig() {
   return {
     parser: "svelte-eslint-parser",
-    parserOptions: BASIC_PARSER_OPTIONS,
+    parserOptions: generateParserOptions(),
     rules: {
       "@typescript-eslint/no-unsafe-argument": "error",
       "@typescript-eslint/no-unsafe-assignment": "error",

--- a/tests/fixtures/integrations/type-info-tests/reactive2-setup.ts
+++ b/tests/fixtures/integrations/type-info-tests/reactive2-setup.ts
@@ -1,6 +1,6 @@
 /* eslint eslint-comments/require-description: 0, @typescript-eslint/explicit-module-boundary-types: 0 */
 import type { Linter } from "eslint";
-import { BASIC_PARSER_OPTIONS } from "../../../src/parser/test-utils";
+import { generateParserOptions } from "../../../src/parser/test-utils";
 import { rules } from "@typescript-eslint/eslint-plugin";
 export function setupLinter(linter: Linter) {
   linter.defineRule(
@@ -16,7 +16,7 @@ export function setupLinter(linter: Linter) {
 export function getConfig() {
   return {
     parser: "svelte-eslint-parser",
-    parserOptions: BASIC_PARSER_OPTIONS,
+    parserOptions: generateParserOptions(),
     rules: {
       "@typescript-eslint/no-unsafe-assignment": "error",
       "@typescript-eslint/no-unsafe-member-access": "error",

--- a/tests/fixtures/integrations/type-info-tests/ts-newline-setup.ts
+++ b/tests/fixtures/integrations/type-info-tests/ts-newline-setup.ts
@@ -1,6 +1,6 @@
 /* eslint eslint-comments/require-description: 0, @typescript-eslint/explicit-module-boundary-types: 0 */
 import type { Linter } from "eslint";
-import { BASIC_PARSER_OPTIONS } from "../../../src/parser/test-utils";
+import { generateParserOptions } from "../../../src/parser/test-utils";
 import { rules } from "@typescript-eslint/eslint-plugin";
 export function setupLinter(linter: Linter) {
   linter.defineRule(
@@ -16,7 +16,7 @@ export function setupLinter(linter: Linter) {
 export function getConfig() {
   return {
     parser: "svelte-eslint-parser",
-    parserOptions: BASIC_PARSER_OPTIONS,
+    parserOptions: generateParserOptions(),
     rules: {
       "@typescript-eslint/no-confusing-void-expression": "error",
       "@typescript-eslint/explicit-function-return-type": "error",

--- a/tests/fixtures/integrations/type-info-tests/ts-no-misused-promises-setup.ts
+++ b/tests/fixtures/integrations/type-info-tests/ts-no-misused-promises-setup.ts
@@ -1,6 +1,6 @@
 /* eslint eslint-comments/require-description: 0, @typescript-eslint/explicit-module-boundary-types: 0 */
 import type { Linter } from "eslint";
-import { BASIC_PARSER_OPTIONS } from "../../../src/parser/test-utils";
+import { generateParserOptions } from "../../../src/parser/test-utils";
 import { rules } from "@typescript-eslint/eslint-plugin";
 export function setupLinter(linter: Linter) {
   linter.defineRule(
@@ -12,7 +12,7 @@ export function setupLinter(linter: Linter) {
 export function getConfig() {
   return {
     parser: "svelte-eslint-parser",
-    parserOptions: BASIC_PARSER_OPTIONS,
+    parserOptions: generateParserOptions(),
     rules: {
       "@typescript-eslint/no-misused-promises": "error",
     },

--- a/tests/fixtures/parser/ast/ts-event05-input.svelte
+++ b/tests/fixtures/parser/ast/ts-event05-input.svelte
@@ -3,6 +3,9 @@
 </script>
 
 <Component on:foo="{e=>{
-    // TODO: e.detail is number
+    // e.detail is number
+    //   `@typescript-eslint/parser` doesn't get the correct types.
+    //   Using `typescript-eslint-parser-for-extra-files` will give we the correct types.
+    //   See `ts-event06-input.svelte` test case
     e.detail;
 }}" />

--- a/tests/fixtures/parser/ast/ts-event05-type-output.svelte
+++ b/tests/fixtures/parser/ast/ts-event05-type-output.svelte
@@ -3,6 +3,9 @@
 </script>
 
 <Component on:foo="{e=>{ // Component: typeof SvelteComponentDev, e: CustomEvent<any>
-    // TODO: e.detail is number
+    // e.detail is number
+    //   `@typescript-eslint/parser` doesn't get the correct types.
+    //   Using `typescript-eslint-parser-for-extra-files` will give we the correct types.
+    //   See `ts-event06-input.svelte` test case
     e.detail; // e.detail: any
 }}" />

--- a/tests/fixtures/parser/ast/ts-event06-config.json
+++ b/tests/fixtures/parser/ast/ts-event06-config.json
@@ -1,0 +1,3 @@
+{
+    "parser": "typescript-eslint-parser-for-extra-files"
+}

--- a/tests/fixtures/parser/ast/ts-event06-input.svelte
+++ b/tests/fixtures/parser/ast/ts-event06-input.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+    import Component from './ts-event03-input.svelte';
+</script>
+
+<Component on:foo="{e=>{
+    // e.detail is number
+    e.detail;
+}}" />

--- a/tests/fixtures/parser/ast/ts-event06-no-unused-expressions-result.json
+++ b/tests/fixtures/parser/ast/ts-event06-no-unused-expressions-result.json
@@ -2,7 +2,7 @@
   {
     "ruleId": "no-unused-expressions",
     "code": "e.detail;",
-    "line": 10,
+    "line": 7,
     "column": 5
   }
 ]

--- a/tests/fixtures/parser/ast/ts-event06-output.json
+++ b/tests/fixtures/parser/ast/ts-event06-output.json
@@ -301,16 +301,16 @@
                         "type": "Identifier",
                         "name": "e",
                         "range": [
-                          347,
-                          348
+                          140,
+                          141
                         ],
                         "loc": {
                           "start": {
-                            "line": 10,
+                            "line": 7,
                             "column": 4
                           },
                           "end": {
-                            "line": 10,
+                            "line": 7,
                             "column": 5
                           }
                         }
@@ -320,46 +320,46 @@
                         "type": "Identifier",
                         "name": "detail",
                         "range": [
-                          349,
-                          355
+                          142,
+                          148
                         ],
                         "loc": {
                           "start": {
-                            "line": 10,
+                            "line": 7,
                             "column": 6
                           },
                           "end": {
-                            "line": 10,
+                            "line": 7,
                             "column": 12
                           }
                         }
                       },
                       "range": [
-                        347,
-                        355
+                        140,
+                        148
                       ],
                       "loc": {
                         "start": {
-                          "line": 10,
+                          "line": 7,
                           "column": 4
                         },
                         "end": {
-                          "line": 10,
+                          "line": 7,
                           "column": 12
                         }
                       }
                     },
                     "range": [
-                      347,
-                      356
+                      140,
+                      149
                     ],
                     "loc": {
                       "start": {
-                        "line": 10,
+                        "line": 7,
                         "column": 4
                       },
                       "end": {
-                        "line": 10,
+                        "line": 7,
                         "column": 13
                       }
                     }
@@ -367,7 +367,7 @@
                 ],
                 "range": [
                   108,
-                  358
+                  151
                 ],
                 "loc": {
                   "start": {
@@ -375,7 +375,7 @@
                     "column": 23
                   },
                   "end": {
-                    "line": 11,
+                    "line": 8,
                     "column": 1
                   }
                 }
@@ -405,7 +405,7 @@
               ],
               "range": [
                 105,
-                358
+                151
               ],
               "loc": {
                 "start": {
@@ -413,14 +413,14 @@
                   "column": 20
                 },
                 "end": {
-                  "line": 11,
+                  "line": 8,
                   "column": 1
                 }
               }
             },
             "range": [
               96,
-              360
+              153
             ],
             "loc": {
               "start": {
@@ -428,7 +428,7 @@
                 "column": 11
               },
               "end": {
-                "line": 11,
+                "line": 8,
                 "column": 3
               }
             }
@@ -437,7 +437,7 @@
         "selfClosing": true,
         "range": [
           85,
-          363
+          156
         ],
         "loc": {
           "start": {
@@ -445,7 +445,7 @@
             "column": 0
           },
           "end": {
-            "line": 11,
+            "line": 8,
             "column": 6
           }
         }
@@ -454,7 +454,7 @@
       "endTag": null,
       "range": [
         85,
-        363
+        156
       ],
       "loc": {
         "start": {
@@ -462,7 +462,7 @@
           "column": 0
         },
         "end": {
-          "line": 11,
+          "line": 8,
           "column": 6
         }
       }
@@ -485,60 +485,6 @@
         "end": {
           "line": 6,
           "column": 25
-        }
-      }
-    },
-    {
-      "type": "Line",
-      "value": "   `@typescript-eslint/parser` doesn't get the correct types.",
-      "range": [
-        140,
-        203
-      ],
-      "loc": {
-        "start": {
-          "line": 7,
-          "column": 4
-        },
-        "end": {
-          "line": 7,
-          "column": 67
-        }
-      }
-    },
-    {
-      "type": "Line",
-      "value": "   Using `typescript-eslint-parser-for-extra-files` will give we the correct types.",
-      "range": [
-        208,
-        293
-      ],
-      "loc": {
-        "start": {
-          "line": 8,
-          "column": 4
-        },
-        "end": {
-          "line": 8,
-          "column": 89
-        }
-      }
-    },
-    {
-      "type": "Line",
-      "value": "   See `ts-event06-input.svelte` test case",
-      "range": [
-        298,
-        342
-      ],
-      "loc": {
-        "start": {
-          "line": 9,
-          "column": 4
-        },
-        "end": {
-          "line": 9,
-          "column": 48
         }
       }
     }
@@ -1070,16 +1016,16 @@
       "type": "Identifier",
       "value": "e",
       "range": [
-        347,
-        348
+        140,
+        141
       ],
       "loc": {
         "start": {
-          "line": 10,
+          "line": 7,
           "column": 4
         },
         "end": {
-          "line": 10,
+          "line": 7,
           "column": 5
         }
       }
@@ -1088,16 +1034,16 @@
       "type": "Punctuator",
       "value": ".",
       "range": [
-        348,
-        349
+        141,
+        142
       ],
       "loc": {
         "start": {
-          "line": 10,
+          "line": 7,
           "column": 5
         },
         "end": {
-          "line": 10,
+          "line": 7,
           "column": 6
         }
       }
@@ -1106,16 +1052,16 @@
       "type": "Identifier",
       "value": "detail",
       "range": [
-        349,
-        355
+        142,
+        148
       ],
       "loc": {
         "start": {
-          "line": 10,
+          "line": 7,
           "column": 6
         },
         "end": {
-          "line": 10,
+          "line": 7,
           "column": 12
         }
       }
@@ -1124,16 +1070,16 @@
       "type": "Punctuator",
       "value": ";",
       "range": [
-        355,
-        356
+        148,
+        149
       ],
       "loc": {
         "start": {
-          "line": 10,
+          "line": 7,
           "column": 12
         },
         "end": {
-          "line": 10,
+          "line": 7,
           "column": 13
         }
       }
@@ -1142,16 +1088,16 @@
       "type": "Punctuator",
       "value": "}",
       "range": [
-        357,
-        358
+        150,
+        151
       ],
       "loc": {
         "start": {
-          "line": 11,
+          "line": 8,
           "column": 0
         },
         "end": {
-          "line": 11,
+          "line": 8,
           "column": 1
         }
       }
@@ -1160,16 +1106,16 @@
       "type": "Punctuator",
       "value": "}",
       "range": [
-        358,
-        359
+        151,
+        152
       ],
       "loc": {
         "start": {
-          "line": 11,
+          "line": 8,
           "column": 1
         },
         "end": {
-          "line": 11,
+          "line": 8,
           "column": 2
         }
       }
@@ -1178,16 +1124,16 @@
       "type": "Punctuator",
       "value": "\"",
       "range": [
-        359,
-        360
+        152,
+        153
       ],
       "loc": {
         "start": {
-          "line": 11,
+          "line": 8,
           "column": 2
         },
         "end": {
-          "line": 11,
+          "line": 8,
           "column": 3
         }
       }
@@ -1196,16 +1142,16 @@
       "type": "Punctuator",
       "value": "/",
       "range": [
-        361,
-        362
+        154,
+        155
       ],
       "loc": {
         "start": {
-          "line": 11,
+          "line": 8,
           "column": 4
         },
         "end": {
-          "line": 11,
+          "line": 8,
           "column": 5
         }
       }
@@ -1214,16 +1160,16 @@
       "type": "Punctuator",
       "value": ">",
       "range": [
-        362,
-        363
+        155,
+        156
       ],
       "loc": {
         "start": {
-          "line": 11,
+          "line": 8,
           "column": 5
         },
         "end": {
-          "line": 11,
+          "line": 8,
           "column": 6
         }
       }
@@ -1231,7 +1177,7 @@
   ],
   "range": [
     0,
-    364
+    157
   ],
   "loc": {
     "start": {
@@ -1239,7 +1185,7 @@
       "column": 0
     },
     "end": {
-      "line": 12,
+      "line": 9,
       "column": 0
     }
   }

--- a/tests/fixtures/parser/ast/ts-event06-scope-output.json
+++ b/tests/fixtures/parser/ast/ts-event06-scope-output.json
@@ -8833,16 +8833,16 @@
                               "type": "Identifier",
                               "name": "e",
                               "range": [
-                                347,
-                                348
+                                140,
+                                141
                               ],
                               "loc": {
                                 "start": {
-                                  "line": 10,
+                                  "line": 7,
                                   "column": 4
                                 },
                                 "end": {
-                                  "line": 10,
+                                  "line": 7,
                                   "column": 5
                                 }
                               }
@@ -8852,46 +8852,46 @@
                               "type": "Identifier",
                               "name": "detail",
                               "range": [
-                                349,
-                                355
+                                142,
+                                148
                               ],
                               "loc": {
                                 "start": {
-                                  "line": 10,
+                                  "line": 7,
                                   "column": 6
                                 },
                                 "end": {
-                                  "line": 10,
+                                  "line": 7,
                                   "column": 12
                                 }
                               }
                             },
                             "range": [
-                              347,
-                              355
+                              140,
+                              148
                             ],
                             "loc": {
                               "start": {
-                                "line": 10,
+                                "line": 7,
                                 "column": 4
                               },
                               "end": {
-                                "line": 10,
+                                "line": 7,
                                 "column": 12
                               }
                             }
                           },
                           "range": [
-                            347,
-                            356
+                            140,
+                            149
                           ],
                           "loc": {
                             "start": {
-                              "line": 10,
+                              "line": 7,
                               "column": 4
                             },
                             "end": {
-                              "line": 10,
+                              "line": 7,
                               "column": 13
                             }
                           }
@@ -8899,7 +8899,7 @@
                       ],
                       "range": [
                         108,
-                        358
+                        151
                       ],
                       "loc": {
                         "start": {
@@ -8907,7 +8907,7 @@
                           "column": 23
                         },
                         "end": {
-                          "line": 11,
+                          "line": 8,
                           "column": 1
                         }
                       }
@@ -8937,7 +8937,7 @@
                     ],
                     "range": [
                       105,
-                      358
+                      151
                     ],
                     "loc": {
                       "start": {
@@ -8945,7 +8945,7 @@
                         "column": 20
                       },
                       "end": {
-                        "line": 11,
+                        "line": 8,
                         "column": 1
                       }
                     }
@@ -8958,16 +8958,16 @@
                     "type": "Identifier",
                     "name": "e",
                     "range": [
-                      347,
-                      348
+                      140,
+                      141
                     ],
                     "loc": {
                       "start": {
-                        "line": 10,
+                        "line": 7,
                         "column": 4
                       },
                       "end": {
-                        "line": 10,
+                        "line": 7,
                         "column": 5
                       }
                     }
@@ -9002,16 +9002,16 @@
                 "type": "Identifier",
                 "name": "e",
                 "range": [
-                  347,
-                  348
+                  140,
+                  141
                 ],
                 "loc": {
                   "start": {
-                    "line": 10,
+                    "line": 7,
                     "column": 4
                   },
                   "end": {
-                    "line": 10,
+                    "line": 7,
                     "column": 5
                   }
                 }

--- a/tests/fixtures/parser/ast/ts-event06-type-output.svelte
+++ b/tests/fixtures/parser/ast/ts-event06-type-output.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+    import Component from './ts-event03-input.svelte'; // Component: typeof TsEvent03Input__SvelteComponent_
+</script>
+
+<Component on:foo="{e=>{ // Component: typeof TsEvent03Input__SvelteComponent_, e: CustomEvent<number>
+    // e.detail is number
+    e.detail; // e.detail: number
+}}" />

--- a/tests/src/integrations.ts
+++ b/tests/src/integrations.ts
@@ -39,7 +39,7 @@ describe("Integration tests.", () => {
         input,
         setup?.getConfig?.() ?? {
           parser: "svelte-eslint-parser",
-          parserOptions: generateParserOptions(inputFileName, config),
+          parserOptions: generateParserOptions(config),
           env: {
             browser: true,
             es2021: true,

--- a/tests/src/integrations.ts
+++ b/tests/src/integrations.ts
@@ -4,7 +4,7 @@ import assert from "assert";
 import fs from "fs";
 import * as parser from "../../src";
 import {
-  BASIC_PARSER_OPTIONS,
+  generateParserOptions,
   getMessageData,
   listupFixtures,
 } from "./parser/test-utils";
@@ -21,7 +21,7 @@ function createLinter() {
 }
 
 describe("Integration tests.", () => {
-  for (const { input, inputFileName, outputFileName } of listupFixtures(
+  for (const { input, inputFileName, outputFileName, config } of listupFixtures(
     FIXTURE_ROOT
   )) {
     it(inputFileName, () => {
@@ -39,7 +39,7 @@ describe("Integration tests.", () => {
         input,
         setup?.getConfig?.() ?? {
           parser: "svelte-eslint-parser",
-          parserOptions: BASIC_PARSER_OPTIONS,
+          parserOptions: generateParserOptions(inputFileName, config),
           env: {
             browser: true,
             es2021: true,

--- a/tests/src/parser/error.ts
+++ b/tests/src/parser/error.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import fs from "fs";
 import { parseForESLint } from "../../../src";
 import {
-  BASIC_PARSER_OPTIONS,
+  generateParserOptions,
   listupFixtures,
   astToJson,
   normalizeError,
@@ -14,11 +14,8 @@ const ERROR_FIXTURE_ROOT = path.resolve(
   "../../fixtures/parser/error"
 );
 
-function parse(code: string, filePath: string) {
-  return parseForESLint(code, {
-    ...BASIC_PARSER_OPTIONS!,
-    filePath,
-  });
+function parse(code: string, filePath: string, config: any) {
+  return parseForESLint(code, generateParserOptions(filePath, config));
 }
 
 describe("Check for Error.", () => {
@@ -26,6 +23,7 @@ describe("Check for Error.", () => {
     input,
     inputFileName,
     outputFileName,
+    config,
     meetRequirements,
   } of listupFixtures(ERROR_FIXTURE_ROOT)) {
     describe(inputFileName, () => {
@@ -34,7 +32,7 @@ describe("Check for Error.", () => {
       }
       it("most to the expected error.", () => {
         try {
-          parse(input, inputFileName);
+          parse(input, inputFileName, config);
         } catch (e) {
           const errorJson = astToJson(normalizeError(e));
           const output = fs.readFileSync(outputFileName, "utf8");

--- a/tests/src/parser/error.ts
+++ b/tests/src/parser/error.ts
@@ -15,7 +15,7 @@ const ERROR_FIXTURE_ROOT = path.resolve(
 );
 
 function parse(code: string, filePath: string, config: any) {
-  return parseForESLint(code, generateParserOptions(filePath, config));
+  return parseForESLint(code, generateParserOptions({ filePath }, config));
 }
 
 describe("Check for Error.", () => {

--- a/tests/src/parser/eslint-rules.ts
+++ b/tests/src/parser/eslint-rules.ts
@@ -51,7 +51,7 @@ describe("svelte-eslint-parser with ESLint rules", () => {
             input,
             {
               parser: "svelte-eslint-parser",
-              parserOptions: generateParserOptions(inputFileName, config),
+              parserOptions: generateParserOptions(config),
               rules: {
                 [rule]: "error",
               },

--- a/tests/src/parser/eslint-rules.ts
+++ b/tests/src/parser/eslint-rules.ts
@@ -3,7 +3,7 @@ import assert from "assert";
 import fs from "fs";
 import * as parser from "../../../src/index";
 import {
-  BASIC_PARSER_OPTIONS,
+  generateParserOptions,
   getMessageData,
   listupFixtures,
 } from "./test-utils";
@@ -39,6 +39,7 @@ describe("svelte-eslint-parser with ESLint rules", () => {
   for (const {
     input,
     inputFileName,
+    config,
     getRuleOutputFileName,
   } of listupFixtures()) {
     const linter = createLinter();
@@ -50,7 +51,7 @@ describe("svelte-eslint-parser with ESLint rules", () => {
             input,
             {
               parser: "svelte-eslint-parser",
-              parserOptions: BASIC_PARSER_OPTIONS,
+              parserOptions: generateParserOptions(inputFileName, config),
               rules: {
                 [rule]: "error",
               },

--- a/tests/src/parser/eslint.ts
+++ b/tests/src/parser/eslint.ts
@@ -2,7 +2,7 @@ import { Linter } from "eslint";
 import assert from "assert";
 import semver from "semver";
 import * as parser from "../../../src/index";
-import { BASIC_PARSER_OPTIONS } from "./test-utils";
+import { generateParserOptions } from "./test-utils";
 
 function createLinter() {
   const linter = new Linter();
@@ -246,10 +246,7 @@ describe("eslint custom parser", () => {
         const linter = createLinter();
         const result = linter.verifyAndFix(code, {
           parser: "svelte-eslint-parser",
-          parserOptions: {
-            ...BASIC_PARSER_OPTIONS,
-            ...(parserOptions ? parserOptions : {}),
-          },
+          parserOptions: generateParserOptions(parserOptions),
           rules: {
             "no-unused-labels": "error",
             "no-extra-label": "error",

--- a/tests/src/parser/parser.ts
+++ b/tests/src/parser/parser.ts
@@ -15,7 +15,7 @@ import type { Comment, SvelteProgram, Token } from "../../../src/ast";
 import { sortNodes } from "../../../src/parser/sort";
 
 function parse(code: string, filePath: string, config: any) {
-  return parseForESLint(code, generateParserOptions(filePath, config));
+  return parseForESLint(code, generateParserOptions({ filePath }, config));
 }
 
 describe("Check for AST.", () => {

--- a/tests/src/parser/parser.ts
+++ b/tests/src/parser/parser.ts
@@ -6,7 +6,7 @@ import semver from "semver";
 import { traverseNodes } from "../../../src/traverse";
 import { parseForESLint } from "../../../src";
 import {
-  BASIC_PARSER_OPTIONS,
+  generateParserOptions,
   listupFixtures,
   astToJson,
   scopeToJSON,
@@ -14,11 +14,8 @@ import {
 import type { Comment, SvelteProgram, Token } from "../../../src/ast";
 import { sortNodes } from "../../../src/parser/sort";
 
-function parse(code: string, filePath: string) {
-  return parseForESLint(code, {
-    ...BASIC_PARSER_OPTIONS!,
-    filePath,
-  });
+function parse(code: string, filePath: string, config: any) {
+  return parseForESLint(code, generateParserOptions(filePath, config));
 }
 
 describe("Check for AST.", () => {
@@ -27,13 +24,14 @@ describe("Check for AST.", () => {
     inputFileName,
     outputFileName,
     scopeFileName,
+    config,
     meetRequirements,
   } of listupFixtures()) {
     describe(inputFileName, () => {
       let result: any;
 
       it("most to generate the expected AST.", () => {
-        result = parse(input, inputFileName);
+        result = parse(input, inputFileName, config);
         if (!meetRequirements("test")) {
           return;
         }
@@ -72,7 +70,7 @@ describe("Check for AST.", () => {
       it("even if Win, it must be correct.", () => {
         const inputForWin = input.replace(/\n/g, "\r\n");
         // check
-        const astForWin = parse(inputForWin, inputFileName).ast;
+        const astForWin = parse(inputForWin, inputFileName, config).ast;
         // check tokens
         checkTokens(astForWin, inputForWin);
       });

--- a/tests/src/parser/test-utils.ts
+++ b/tests/src/parser/test-utils.ts
@@ -9,7 +9,7 @@ import type * as TSESScopes from "@typescript-eslint/scope-manager";
 import type { SvelteNode } from "../../../src/ast";
 
 const AST_FIXTURE_ROOT = path.resolve(__dirname, "../../fixtures/parser/ast");
-export const BASIC_PARSER_OPTIONS: Linter.BaseConfig["parserOptions"] = {
+const BASIC_PARSER_OPTIONS: Linter.ParserOptions = {
   ecmaVersion: 2020,
   parser: {
     ts: "@typescript-eslint/parser",
@@ -18,12 +18,23 @@ export const BASIC_PARSER_OPTIONS: Linter.BaseConfig["parserOptions"] = {
   project: require.resolve("../../fixtures/tsconfig.test.json"),
   extraFileExtensions: [".svelte"],
 };
-export function* listupFixtures(dir?: string): IterableIterator<{
+export function generateParserOptions(
+  filePath: string,
+  options: Linter.ParserOptions
+): Linter.ParserOptions {
+  return {
+    ...BASIC_PARSER_OPTIONS,
+    filePath,
+    ...options,
+  };
+}
+export function* listupFixtures(dir?: string): Iterable<{
   input: string;
   inputFileName: string;
   outputFileName: string;
   scopeFileName: string;
   typeFileName: string | null;
+  config: Linter.ParserOptions;
   requirements: {
     scope?: Record<string, string>;
   };
@@ -33,12 +44,13 @@ export function* listupFixtures(dir?: string): IterableIterator<{
   yield* listupFixturesImpl(dir || AST_FIXTURE_ROOT);
 }
 
-function* listupFixturesImpl(dir: string): IterableIterator<{
+function* listupFixturesImpl(dir: string): Iterable<{
   input: string;
   inputFileName: string;
   outputFileName: string;
   scopeFileName: string;
   typeFileName: string | null;
+  config: Linter.ParserOptions;
   requirements: {
     scope?: Record<string, string>;
   };
@@ -60,6 +72,10 @@ function* listupFixturesImpl(dir: string): IterableIterator<{
         /input\.svelte$/u,
         "type-output.svelte"
       );
+      const configFileName = inputFileName.replace(
+        /input\.svelte$/u,
+        "config.json"
+      );
       const requirementsFileName = inputFileName.replace(
         /input\.svelte$/u,
         "requirements.json"
@@ -69,12 +85,16 @@ function* listupFixturesImpl(dir: string): IterableIterator<{
       const requirements = fs.existsSync(requirementsFileName)
         ? JSON.parse(fs.readFileSync(requirementsFileName, "utf-8"))
         : {};
+      const config = fs.existsSync(configFileName)
+        ? JSON.parse(fs.readFileSync(configFileName, "utf-8"))
+        : {};
       yield {
         input,
         inputFileName,
         outputFileName,
         scopeFileName,
         typeFileName: fs.existsSync(typeFileName) ? typeFileName : null,
+        config,
         requirements,
         getRuleOutputFileName: (ruleName) => {
           return inputFileName.replace(

--- a/tests/src/parser/test-utils.ts
+++ b/tests/src/parser/test-utils.ts
@@ -19,14 +19,13 @@ const BASIC_PARSER_OPTIONS: Linter.ParserOptions = {
   extraFileExtensions: [".svelte"],
 };
 export function generateParserOptions(
-  filePath: string,
-  options: Linter.ParserOptions
+  ...options: Linter.ParserOptions[]
 ): Linter.ParserOptions {
-  return {
-    ...BASIC_PARSER_OPTIONS,
-    filePath,
-    ...options,
-  };
+  let result = { ...BASIC_PARSER_OPTIONS };
+  for (const option of options) {
+    result = { ...result, ...option };
+  }
+  return result;
 }
 export function* listupFixtures(dir?: string): Iterable<{
   input: string;

--- a/tests/src/parser/typescript/index.ts
+++ b/tests/src/parser/typescript/index.ts
@@ -16,8 +16,7 @@ describe("Check for typescript analyze result.", () => {
       continue;
     }
     describe(inputFileName, () => {
-      const parserOptions = {
-        ...generateParserOptions(inputFileName, config),
+      const parserOptions = generateParserOptions(config, {
         ecmaVersion: 2020,
         sourceType: "module",
         loc: true,
@@ -28,8 +27,7 @@ describe("Check for typescript analyze result.", () => {
         eslintVisitorKeys: true,
         eslintScopeManager: true,
         filePath: inputFileName,
-      };
-
+      });
       const ctx = new Context(input, parserOptions);
       parseTemplate(ctx.sourceCode.template, ctx, parserOptions);
 

--- a/tests/src/parser/typescript/index.ts
+++ b/tests/src/parser/typescript/index.ts
@@ -2,17 +2,22 @@ import { Context } from "../../../../src/context";
 import { parseScript } from "../../../../src/parser/script";
 import { parseTemplate } from "../../../../src/parser/template";
 import { parseTypeScript } from "../../../../src/parser/typescript";
-import { BASIC_PARSER_OPTIONS, listupFixtures } from "../test-utils";
+import { generateParserOptions, listupFixtures } from "../test-utils";
 import { assertResult } from "./assert-result";
 
 describe("Check for typescript analyze result.", () => {
-  for (const { input, inputFileName, meetRequirements } of listupFixtures()) {
+  for (const {
+    input,
+    inputFileName,
+    config,
+    meetRequirements,
+  } of listupFixtures()) {
     if (!input.includes('lang="ts"')) {
       continue;
     }
     describe(inputFileName, () => {
       const parserOptions = {
-        ...BASIC_PARSER_OPTIONS,
+        ...generateParserOptions(inputFileName, config),
         ecmaVersion: 2020,
         sourceType: "module",
         loc: true,

--- a/tools/update-fixtures.ts
+++ b/tools/update-fixtures.ts
@@ -38,7 +38,7 @@ const RULES = [
  * Parse
  */
 function parse(code: string, filePath: string, config: any) {
-  return parseForESLint(code, generateParserOptions(filePath, config));
+  return parseForESLint(code, generateParserOptions({ filePath }, config));
 }
 
 for (const {
@@ -76,7 +76,7 @@ for (const {
       input,
       {
         parser: "svelte-eslint-parser",
-        parserOptions: generateParserOptions(inputFileName, config),
+        parserOptions: generateParserOptions(config),
         rules: {
           [rule]: "error",
         },

--- a/tools/update-fixtures.ts
+++ b/tools/update-fixtures.ts
@@ -4,7 +4,7 @@ import { Linter } from "eslint";
 import * as parser from "../src/index";
 import { parseForESLint } from "../src/parser";
 import {
-  BASIC_PARSER_OPTIONS,
+  generateParserOptions,
   getMessageData,
   listupFixtures,
   astToJson,
@@ -37,11 +37,8 @@ const RULES = [
 /**
  * Parse
  */
-function parse(code: string, filePath: string) {
-  return parseForESLint(code, {
-    ...BASIC_PARSER_OPTIONS!,
-    filePath,
-  });
+function parse(code: string, filePath: string, config: any) {
+  return parseForESLint(code, generateParserOptions(filePath, config));
 }
 
 for (const {
@@ -50,13 +47,14 @@ for (const {
   outputFileName,
   scopeFileName,
   typeFileName,
+  config,
   getRuleOutputFileName,
 } of listupFixtures()) {
   // if (!inputFileName.includes("test")) continue;
   try {
     // eslint-disable-next-line no-console -- ignore
     console.log(inputFileName);
-    const result = parse(input, inputFileName);
+    const result = parse(input, inputFileName, config);
     const astJson = astToJson(result.ast);
     fs.writeFileSync(outputFileName, astJson, "utf8");
     const scopeJson = scopeToJSON(result.scopeManager);
@@ -78,7 +76,7 @@ for (const {
       input,
       {
         parser: "svelte-eslint-parser",
-        parserOptions: BASIC_PARSER_OPTIONS,
+        parserOptions: generateParserOptions(inputFileName, config),
         rules: {
           [rule]: "error",
         },
@@ -105,13 +103,13 @@ for (const {
   }
 }
 
-for (const { input, inputFileName, outputFileName } of listupFixtures(
+for (const { input, inputFileName, outputFileName, config } of listupFixtures(
   ERROR_FIXTURE_ROOT
 )) {
   // eslint-disable-next-line no-console -- ignore
   console.log(inputFileName);
   try {
-    parse(input, inputFileName);
+    parse(input, inputFileName, config);
   } catch (e) {
     const errorJson = astToJson(normalizeError(e));
     fs.writeFileSync(outputFileName, errorJson, "utf8");


### PR DESCRIPTION
Related to https://github.com/sveltejs/eslint-plugin-svelte/issues/432

This PR improves assigning the correct event handler type when the component type is available.

However, since `@typescript-eslint/parser` cannot be used to retrieve component types, users should use the experimental parser `typescript-eslint-parser-for-extra-files` instead. .
If the user is using `@typescript-eslint/parser` it will be the same as before.