### PR TITLE
feat: support for `use:` directive parameter type

### DIFF
--- a/.changeset/wet-lizards-reflect.md
+++ b/.changeset/wet-lizards-reflect.md
@@ -1,0 +1,5 @@
+---
+"svelte-eslint-parser": minor
+---
+
+feat: support for `use:` directive parameter type

--- a/src/parser/converts/attr.ts
+++ b/src/parser/converts/attr.ts
@@ -548,7 +548,7 @@ function convertActionDirective(
     processExpression: buildProcessExpressionForExpression(
       directive,
       ctx,
-      null
+      `Parameters<typeof ${node.name}>[1]`
     ),
     processName: (name) =>
       ctx.scriptLet.addExpression(

--- a/tests/fixtures/parser/ast/ts-use01-input.svelte
+++ b/tests/fixtures/parser/ast/ts-use01-input.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  type MyActionParam = () => (p: { foo: number }) => void;
+  function myAction(_node: HTMLElement, params: MyActionParam) {
+    const result = params();
+    result({ foo: 1 });
+    return {
+      destroy: () => {},
+    };
+  }
+</script>
+
+<div
+  use:myAction={() => {
+    return (param) => {
+      param.foo;
+    };
+  }}
+/>

--- a/tests/fixtures/parser/ast/ts-use01-no-unused-expressions-result.json
+++ b/tests/fixtures/parser/ast/ts-use01-no-unused-expressions-result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "ruleId": "no-unused-expressions",
+    "code": "param.foo;",
+    "line": 15,
+    "column": 7
+  }
+]

--- a/tests/fixtures/parser/ast/ts-use01-no-unused-vars-result.json
+++ b/tests/fixtures/parser/ast/ts-use01-no-unused-vars-result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "ruleId": "no-unused-vars",
+    "code": "p: { foo: number }",
+    "line": 2,
+    "column": 31
+  }
+]

--- a/tests/fixtures/parser/ast/ts-use01-output.json
+++ b/tests/fixtures/parser/ast/ts-use01-output.json
@@ -1,0 +1,3040 @@
+{
+  "type": "Program",
+  "body": [
+    {
+      "type": "SvelteScriptElement",
+      "name": {
+        "type": "SvelteName",
+        "name": "script",
+        "range": [
+          1,
+          7
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        }
+      },
+      "startTag": {
+        "type": "SvelteStartTag",
+        "attributes": [
+          {
+            "type": "SvelteAttribute",
+            "key": {
+              "type": "SvelteName",
+              "name": "lang",
+              "range": [
+                8,
+                12
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1,
+                  "column": 12
+                }
+              }
+            },
+            "boolean": false,
+            "value": [
+              {
+                "type": "SvelteLiteral",
+                "value": "ts",
+                "range": [
+                  14,
+                  16
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 16
+                  }
+                }
+              }
+            ],
+            "range": [
+              8,
+              17
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 8
+              },
+              "end": {
+                "line": 1,
+                "column": 17
+              }
+            }
+          }
+        ],
+        "selfClosing": false,
+        "range": [
+          0,
+          18
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 18
+          }
+        }
+      },
+      "body": [
+        {
+          "type": "TSTypeAliasDeclaration",
+          "id": {
+            "type": "Identifier",
+            "name": "MyActionParam",
+            "range": [
+              26,
+              39
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 7
+              },
+              "end": {
+                "line": 2,
+                "column": 20
+              }
+            }
+          },
+          "typeAnnotation": {
+            "type": "TSFunctionType",
+            "params": [],
+            "returnType": {
+              "type": "TSTypeAnnotation",
+              "typeAnnotation": {
+                "type": "TSFunctionType",
+                "params": [
+                  {
+                    "type": "Identifier",
+                    "name": "p",
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "typeAnnotation": {
+                        "type": "TSTypeLiteral",
+                        "members": [
+                          {
+                            "type": "TSPropertySignature",
+                            "computed": false,
+                            "key": {
+                              "type": "Identifier",
+                              "name": "foo",
+                              "range": [
+                                54,
+                                57
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 2,
+                                  "column": 35
+                                },
+                                "end": {
+                                  "line": 2,
+                                  "column": 38
+                                }
+                              }
+                            },
+                            "typeAnnotation": {
+                              "type": "TSTypeAnnotation",
+                              "typeAnnotation": {
+                                "type": "TSNumberKeyword",
+                                "range": [
+                                  59,
+                                  65
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 2,
+                                    "column": 40
+                                  },
+                                  "end": {
+                                    "line": 2,
+                                    "column": 46
+                                  }
+                                }
+                              },
+                              "range": [
+                                57,
+                                65
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 2,
+                                  "column": 38
+                                },
+                                "end": {
+                                  "line": 2,
+                                  "column": 46
+                                }
+                              }
+                            },
+                            "range": [
+                              54,
+                              65
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 2,
+                                "column": 35
+                              },
+                              "end": {
+                                "line": 2,
+                                "column": 46
+                              }
+                            }
+                          }
+                        ],
+                        "range": [
+                          52,
+                          67
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 33
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 48
+                          }
+                        }
+                      },
+                      "range": [
+                        50,
+                        67
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 31
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 48
+                        }
+                      }
+                    },
+                    "range": [
+                      49,
+                      67
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 30
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 48
+                      }
+                    }
+                  }
+                ],
+                "returnType": {
+                  "type": "TSTypeAnnotation",
+                  "typeAnnotation": {
+                    "type": "TSVoidKeyword",
+                    "range": [
+                      72,
+                      76
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 53
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 57
+                      }
+                    }
+                  },
+                  "range": [
+                    69,
+                    76
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 50
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 57
+                    }
+                  }
+                },
+                "range": [
+                  48,
+                  76
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 29
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 57
+                  }
+                }
+              },
+              "range": [
+                45,
+                76
+              ],
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 26
+                },
+                "end": {
+                  "line": 2,
+                  "column": 57
+                }
+              }
+            },
+            "range": [
+              42,
+              76
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 23
+              },
+              "end": {
+                "line": 2,
+                "column": 57
+              }
+            }
+          },
+          "range": [
+            21,
+            77
+          ],
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 2
+            },
+            "end": {
+              "line": 2,
+              "column": 58
+            }
+          }
+        },
+        {
+          "type": "FunctionDeclaration",
+          "async": false,
+          "body": {
+            "type": "BlockStatement",
+            "body": [
+              {
+                "type": "VariableDeclaration",
+                "kind": "const",
+                "declarations": [
+                  {
+                    "type": "VariableDeclarator",
+                    "id": {
+                      "type": "Identifier",
+                      "name": "result",
+                      "range": [
+                        153,
+                        159
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 10
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 16
+                        }
+                      }
+                    },
+                    "init": {
+                      "type": "CallExpression",
+                      "arguments": [],
+                      "callee": {
+                        "type": "Identifier",
+                        "name": "params",
+                        "range": [
+                          162,
+                          168
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 4,
+                            "column": 19
+                          },
+                          "end": {
+                            "line": 4,
+                            "column": 25
+                          }
+                        }
+                      },
+                      "optional": false,
+                      "range": [
+                        162,
+                        170
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 19
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 27
+                        }
+                      }
+                    },
+                    "range": [
+                      153,
+                      170
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 10
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 27
+                      }
+                    }
+                  }
+                ],
+                "range": [
+                  147,
+                  171
+                ],
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 28
+                  }
+                }
+              },
+              {
+                "type": "ExpressionStatement",
+                "expression": {
+                  "type": "CallExpression",
+                  "arguments": [
+                    {
+                      "type": "ObjectExpression",
+                      "properties": [
+                        {
+                          "type": "Property",
+                          "kind": "init",
+                          "computed": false,
+                          "key": {
+                            "type": "Identifier",
+                            "name": "foo",
+                            "range": [
+                              185,
+                              188
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 5,
+                                "column": 13
+                              },
+                              "end": {
+                                "line": 5,
+                                "column": 16
+                              }
+                            }
+                          },
+                          "method": false,
+                          "shorthand": false,
+                          "value": {
+                            "type": "Literal",
+                            "raw": "1",
+                            "value": 1,
+                            "range": [
+                              190,
+                              191
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 5,
+                                "column": 18
+                              },
+                              "end": {
+                                "line": 5,
+                                "column": 19
+                              }
+                            }
+                          },
+                          "range": [
+                            185,
+                            191
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 5,
+                              "column": 13
+                            },
+                            "end": {
+                              "line": 5,
+                              "column": 19
+                            }
+                          }
+                        }
+                      ],
+                      "range": [
+                        183,
+                        193
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 5,
+                          "column": 11
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 21
+                        }
+                      }
+                    }
+                  ],
+                  "callee": {
+                    "type": "Identifier",
+                    "name": "result",
+                    "range": [
+                      176,
+                      182
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 4
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 10
+                      }
+                    }
+                  },
+                  "optional": false,
+                  "range": [
+                    176,
+                    194
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 4
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 22
+                    }
+                  }
+                },
+                "range": [
+                  176,
+                  195
+                ],
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 23
+                  }
+                }
+              },
+              {
+                "type": "ReturnStatement",
+                "argument": {
+                  "type": "ObjectExpression",
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "kind": "init",
+                      "computed": false,
+                      "key": {
+                        "type": "Identifier",
+                        "name": "destroy",
+                        "range": [
+                          215,
+                          222
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 7,
+                            "column": 6
+                          },
+                          "end": {
+                            "line": 7,
+                            "column": 13
+                          }
+                        }
+                      },
+                      "method": false,
+                      "shorthand": false,
+                      "value": {
+                        "type": "ArrowFunctionExpression",
+                        "async": false,
+                        "body": {
+                          "type": "BlockStatement",
+                          "body": [],
+                          "range": [
+                            230,
+                            232
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 7,
+                              "column": 21
+                            },
+                            "end": {
+                              "line": 7,
+                              "column": 23
+                            }
+                          }
+                        },
+                        "expression": false,
+                        "generator": false,
+                        "id": null,
+                        "params": [],
+                        "range": [
+                          224,
+                          232
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 7,
+                            "column": 15
+                          },
+                          "end": {
+                            "line": 7,
+                            "column": 23
+                          }
+                        }
+                      },
+                      "range": [
+                        215,
+                        232
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 7,
+                          "column": 6
+                        },
+                        "end": {
+                          "line": 7,
+                          "column": 23
+                        }
+                      }
+                    }
+                  ],
+                  "range": [
+                    207,
+                    239
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 8,
+                      "column": 5
+                    }
+                  }
+                },
+                "range": [
+                  200,
+                  240
+                ],
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 6
+                  }
+                }
+              }
+            ],
+            "range": [
+              141,
+              244
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 63
+              },
+              "end": {
+                "line": 9,
+                "column": 3
+              }
+            }
+          },
+          "expression": false,
+          "generator": false,
+          "id": {
+            "type": "Identifier",
+            "name": "myAction",
+            "range": [
+              89,
+              97
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 11
+              },
+              "end": {
+                "line": 3,
+                "column": 19
+              }
+            }
+          },
+          "params": [
+            {
+              "type": "Identifier",
+              "name": "_node",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "typeAnnotation": {
+                  "type": "TSTypeReference",
+                  "typeName": {
+                    "type": "Identifier",
+                    "name": "HTMLElement",
+                    "range": [
+                      105,
+                      116
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 27
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 38
+                      }
+                    }
+                  },
+                  "range": [
+                    105,
+                    116
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 27
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 38
+                    }
+                  }
+                },
+                "range": [
+                  103,
+                  116
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 25
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 38
+                  }
+                }
+              },
+              "range": [
+                98,
+                116
+              ],
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 20
+                },
+                "end": {
+                  "line": 3,
+                  "column": 38
+                }
+              }
+            },
+            {
+              "type": "Identifier",
+              "name": "params",
+              "typeAnnotation": {
+                "type": "TSTypeAnnotation",
+                "typeAnnotation": {
+                  "type": "TSTypeReference",
+                  "typeName": {
+                    "type": "Identifier",
+                    "name": "MyActionParam",
+                    "range": [
+                      126,
+                      139
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 48
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 61
+                      }
+                    }
+                  },
+                  "range": [
+                    126,
+                    139
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 48
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 61
+                    }
+                  }
+                },
+                "range": [
+                  124,
+                  139
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 46
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 61
+                  }
+                }
+              },
+              "range": [
+                118,
+                139
+              ],
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 40
+                },
+                "end": {
+                  "line": 3,
+                  "column": 61
+                }
+              }
+            }
+          ],
+          "range": [
+            80,
+            244
+          ],
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 2
+            },
+            "end": {
+              "line": 9,
+              "column": 3
+            }
+          }
+        }
+      ],
+      "endTag": {
+        "type": "SvelteEndTag",
+        "range": [
+          245,
+          254
+        ],
+        "loc": {
+          "start": {
+            "line": 10,
+            "column": 0
+          },
+          "end": {
+            "line": 10,
+            "column": 9
+          }
+        }
+      },
+      "range": [
+        0,
+        254
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 10,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": "SvelteText",
+      "value": "\n\n",
+      "range": [
+        254,
+        256
+      ],
+      "loc": {
+        "start": {
+          "line": 10,
+          "column": 9
+        },
+        "end": {
+          "line": 12,
+          "column": 0
+        }
+      }
+    },
+    {
+      "type": "SvelteElement",
+      "kind": "html",
+      "name": {
+        "type": "SvelteName",
+        "name": "div",
+        "range": [
+          257,
+          260
+        ],
+        "loc": {
+          "start": {
+            "line": 12,
+            "column": 1
+          },
+          "end": {
+            "line": 12,
+            "column": 4
+          }
+        }
+      },
+      "startTag": {
+        "type": "SvelteStartTag",
+        "attributes": [
+          {
+            "type": "SvelteDirective",
+            "kind": "Action",
+            "key": {
+              "type": "SvelteDirectiveKey",
+              "name": {
+                "type": "Identifier",
+                "name": "myAction",
+                "range": [
+                  267,
+                  275
+                ],
+                "loc": {
+                  "start": {
+                    "line": 13,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 13,
+                    "column": 14
+                  }
+                }
+              },
+              "modifiers": [],
+              "range": [
+                263,
+                275
+              ],
+              "loc": {
+                "start": {
+                  "line": 13,
+                  "column": 2
+                },
+                "end": {
+                  "line": 13,
+                  "column": 14
+                }
+              }
+            },
+            "expression": {
+              "type": "ArrowFunctionExpression",
+              "async": false,
+              "body": {
+                "type": "BlockStatement",
+                "body": [
+                  {
+                    "type": "ReturnStatement",
+                    "argument": {
+                      "type": "ArrowFunctionExpression",
+                      "async": false,
+                      "body": {
+                        "type": "BlockStatement",
+                        "body": [
+                          {
+                            "type": "ExpressionStatement",
+                            "expression": {
+                              "type": "MemberExpression",
+                              "computed": false,
+                              "object": {
+                                "type": "Identifier",
+                                "name": "param",
+                                "range": [
+                                  315,
+                                  320
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 15,
+                                    "column": 6
+                                  },
+                                  "end": {
+                                    "line": 15,
+                                    "column": 11
+                                  }
+                                }
+                              },
+                              "optional": false,
+                              "property": {
+                                "type": "Identifier",
+                                "name": "foo",
+                                "range": [
+                                  321,
+                                  324
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 15,
+                                    "column": 12
+                                  },
+                                  "end": {
+                                    "line": 15,
+                                    "column": 15
+                                  }
+                                }
+                              },
+                              "range": [
+                                315,
+                                324
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 15,
+                                  "column": 6
+                                },
+                                "end": {
+                                  "line": 15,
+                                  "column": 15
+                                }
+                              }
+                            },
+                            "range": [
+                              315,
+                              325
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 15,
+                                "column": 6
+                              },
+                              "end": {
+                                "line": 15,
+                                "column": 16
+                              }
+                            }
+                          }
+                        ],
+                        "range": [
+                          307,
+                          331
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 14,
+                            "column": 22
+                          },
+                          "end": {
+                            "line": 16,
+                            "column": 5
+                          }
+                        }
+                      },
+                      "expression": false,
+                      "generator": false,
+                      "id": null,
+                      "params": [
+                        {
+                          "type": "Identifier",
+                          "name": "param",
+                          "range": [
+                            297,
+                            302
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 14,
+                              "column": 12
+                            },
+                            "end": {
+                              "line": 14,
+                              "column": 17
+                            }
+                          }
+                        }
+                      ],
+                      "range": [
+                        296,
+                        331
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 14,
+                          "column": 11
+                        },
+                        "end": {
+                          "line": 16,
+                          "column": 5
+                        }
+                      }
+                    },
+                    "range": [
+                      289,
+                      332
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 14,
+                        "column": 4
+                      },
+                      "end": {
+                        "line": 16,
+                        "column": 6
+                      }
+                    }
+                  }
+                ],
+                "range": [
+                  283,
+                  336
+                ],
+                "loc": {
+                  "start": {
+                    "line": 13,
+                    "column": 22
+                  },
+                  "end": {
+                    "line": 17,
+                    "column": 3
+                  }
+                }
+              },
+              "expression": false,
+              "generator": false,
+              "id": null,
+              "params": [],
+              "range": [
+                277,
+                336
+              ],
+              "loc": {
+                "start": {
+                  "line": 13,
+                  "column": 16
+                },
+                "end": {
+                  "line": 17,
+                  "column": 3
+                }
+              }
+            },
+            "range": [
+              263,
+              337
+            ],
+            "loc": {
+              "start": {
+                "line": 13,
+                "column": 2
+              },
+              "end": {
+                "line": 17,
+                "column": 4
+              }
+            }
+          }
+        ],
+        "selfClosing": true,
+        "range": [
+          256,
+          340
+        ],
+        "loc": {
+          "start": {
+            "line": 12,
+            "column": 0
+          },
+          "end": {
+            "line": 18,
+            "column": 2
+          }
+        }
+      },
+      "children": [],
+      "endTag": null,
+      "range": [
+        256,
+        340
+      ],
+      "loc": {
+        "start": {
+          "line": 12,
+          "column": 0
+        },
+        "end": {
+          "line": 18,
+          "column": 2
+        }
+      }
+    }
+  ],
+  "sourceType": "module",
+  "comments": [],
+  "tokens": [
+    {
+      "type": "Punctuator",
+      "value": "<",
+      "range": [
+        0,
+        1
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "script",
+      "range": [
+        1,
+        7
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 1,
+          "column": 7
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "lang",
+      "range": [
+        8,
+        12
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 8
+        },
+        "end": {
+          "line": 1,
+          "column": 12
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "=",
+      "range": [
+        12,
+        13
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 12
+        },
+        "end": {
+          "line": 1,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "\"",
+      "range": [
+        13,
+        14
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 13
+        },
+        "end": {
+          "line": 1,
+          "column": 14
+        }
+      }
+    },
+    {
+      "type": "HTMLText",
+      "value": "ts",
+      "range": [
+        14,
+        16
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 14
+        },
+        "end": {
+          "line": 1,
+          "column": 16
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "\"",
+      "range": [
+        16,
+        17
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 16
+        },
+        "end": {
+          "line": 1,
+          "column": 17
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ">",
+      "range": [
+        17,
+        18
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 17
+        },
+        "end": {
+          "line": 1,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "type",
+      "range": [
+        21,
+        25
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 2,
+          "column": 6
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "MyActionParam",
+      "range": [
+        26,
+        39
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 7
+        },
+        "end": {
+          "line": 2,
+          "column": 20
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "=",
+      "range": [
+        40,
+        41
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 21
+        },
+        "end": {
+          "line": 2,
+          "column": 22
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "(",
+      "range": [
+        42,
+        43
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 23
+        },
+        "end": {
+          "line": 2,
+          "column": 24
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ")",
+      "range": [
+        43,
+        44
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 24
+        },
+        "end": {
+          "line": 2,
+          "column": 25
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "=>",
+      "range": [
+        45,
+        47
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 26
+        },
+        "end": {
+          "line": 2,
+          "column": 28
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "(",
+      "range": [
+        48,
+        49
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 29
+        },
+        "end": {
+          "line": 2,
+          "column": 30
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "p",
+      "range": [
+        49,
+        50
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 30
+        },
+        "end": {
+          "line": 2,
+          "column": 31
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ":",
+      "range": [
+        50,
+        51
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 31
+        },
+        "end": {
+          "line": 2,
+          "column": 32
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        52,
+        53
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 33
+        },
+        "end": {
+          "line": 2,
+          "column": 34
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "foo",
+      "range": [
+        54,
+        57
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 35
+        },
+        "end": {
+          "line": 2,
+          "column": 38
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ":",
+      "range": [
+        57,
+        58
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 38
+        },
+        "end": {
+          "line": 2,
+          "column": 39
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "number",
+      "range": [
+        59,
+        65
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 40
+        },
+        "end": {
+          "line": 2,
+          "column": 46
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        66,
+        67
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 47
+        },
+        "end": {
+          "line": 2,
+          "column": 48
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ")",
+      "range": [
+        67,
+        68
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 48
+        },
+        "end": {
+          "line": 2,
+          "column": 49
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "=>",
+      "range": [
+        69,
+        71
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 50
+        },
+        "end": {
+          "line": 2,
+          "column": 52
+        }
+      }
+    },
+    {
+      "type": "Keyword",
+      "value": "void",
+      "range": [
+        72,
+        76
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 53
+        },
+        "end": {
+          "line": 2,
+          "column": 57
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ";",
+      "range": [
+        76,
+        77
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 57
+        },
+        "end": {
+          "line": 2,
+          "column": 58
+        }
+      }
+    },
+    {
+      "type": "Keyword",
+      "value": "function",
+      "range": [
+        80,
+        88
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 2
+        },
+        "end": {
+          "line": 3,
+          "column": 10
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "myAction",
+      "range": [
+        89,
+        97
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 11
+        },
+        "end": {
+          "line": 3,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "(",
+      "range": [
+        97,
+        98
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 19
+        },
+        "end": {
+          "line": 3,
+          "column": 20
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "_node",
+      "range": [
+        98,
+        103
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 20
+        },
+        "end": {
+          "line": 3,
+          "column": 25
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ":",
+      "range": [
+        103,
+        104
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 25
+        },
+        "end": {
+          "line": 3,
+          "column": 26
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "HTMLElement",
+      "range": [
+        105,
+        116
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 27
+        },
+        "end": {
+          "line": 3,
+          "column": 38
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ",",
+      "range": [
+        116,
+        117
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 38
+        },
+        "end": {
+          "line": 3,
+          "column": 39
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "params",
+      "range": [
+        118,
+        124
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 40
+        },
+        "end": {
+          "line": 3,
+          "column": 46
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ":",
+      "range": [
+        124,
+        125
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 46
+        },
+        "end": {
+          "line": 3,
+          "column": 47
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "MyActionParam",
+      "range": [
+        126,
+        139
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 48
+        },
+        "end": {
+          "line": 3,
+          "column": 61
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ")",
+      "range": [
+        139,
+        140
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 61
+        },
+        "end": {
+          "line": 3,
+          "column": 62
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        141,
+        142
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 63
+        },
+        "end": {
+          "line": 3,
+          "column": 64
+        }
+      }
+    },
+    {
+      "type": "Keyword",
+      "value": "const",
+      "range": [
+        147,
+        152
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 4
+        },
+        "end": {
+          "line": 4,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "result",
+      "range": [
+        153,
+        159
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 10
+        },
+        "end": {
+          "line": 4,
+          "column": 16
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "=",
+      "range": [
+        160,
+        161
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 17
+        },
+        "end": {
+          "line": 4,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "params",
+      "range": [
+        162,
+        168
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 19
+        },
+        "end": {
+          "line": 4,
+          "column": 25
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "(",
+      "range": [
+        168,
+        169
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 25
+        },
+        "end": {
+          "line": 4,
+          "column": 26
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ")",
+      "range": [
+        169,
+        170
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 26
+        },
+        "end": {
+          "line": 4,
+          "column": 27
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ";",
+      "range": [
+        170,
+        171
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 27
+        },
+        "end": {
+          "line": 4,
+          "column": 28
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "result",
+      "range": [
+        176,
+        182
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 4
+        },
+        "end": {
+          "line": 5,
+          "column": 10
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "(",
+      "range": [
+        182,
+        183
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 10
+        },
+        "end": {
+          "line": 5,
+          "column": 11
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        183,
+        184
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 11
+        },
+        "end": {
+          "line": 5,
+          "column": 12
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "foo",
+      "range": [
+        185,
+        188
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 13
+        },
+        "end": {
+          "line": 5,
+          "column": 16
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ":",
+      "range": [
+        188,
+        189
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 16
+        },
+        "end": {
+          "line": 5,
+          "column": 17
+        }
+      }
+    },
+    {
+      "type": "Numeric",
+      "value": "1",
+      "range": [
+        190,
+        191
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 18
+        },
+        "end": {
+          "line": 5,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        192,
+        193
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 20
+        },
+        "end": {
+          "line": 5,
+          "column": 21
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ")",
+      "range": [
+        193,
+        194
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 21
+        },
+        "end": {
+          "line": 5,
+          "column": 22
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ";",
+      "range": [
+        194,
+        195
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 22
+        },
+        "end": {
+          "line": 5,
+          "column": 23
+        }
+      }
+    },
+    {
+      "type": "Keyword",
+      "value": "return",
+      "range": [
+        200,
+        206
+      ],
+      "loc": {
+        "start": {
+          "line": 6,
+          "column": 4
+        },
+        "end": {
+          "line": 6,
+          "column": 10
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        207,
+        208
+      ],
+      "loc": {
+        "start": {
+          "line": 6,
+          "column": 11
+        },
+        "end": {
+          "line": 6,
+          "column": 12
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "destroy",
+      "range": [
+        215,
+        222
+      ],
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 6
+        },
+        "end": {
+          "line": 7,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ":",
+      "range": [
+        222,
+        223
+      ],
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 13
+        },
+        "end": {
+          "line": 7,
+          "column": 14
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "(",
+      "range": [
+        224,
+        225
+      ],
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 15
+        },
+        "end": {
+          "line": 7,
+          "column": 16
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ")",
+      "range": [
+        225,
+        226
+      ],
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 16
+        },
+        "end": {
+          "line": 7,
+          "column": 17
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "=>",
+      "range": [
+        227,
+        229
+      ],
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 18
+        },
+        "end": {
+          "line": 7,
+          "column": 20
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        230,
+        231
+      ],
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 21
+        },
+        "end": {
+          "line": 7,
+          "column": 22
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        231,
+        232
+      ],
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 22
+        },
+        "end": {
+          "line": 7,
+          "column": 23
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ",",
+      "range": [
+        232,
+        233
+      ],
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 23
+        },
+        "end": {
+          "line": 7,
+          "column": 24
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        238,
+        239
+      ],
+      "loc": {
+        "start": {
+          "line": 8,
+          "column": 4
+        },
+        "end": {
+          "line": 8,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ";",
+      "range": [
+        239,
+        240
+      ],
+      "loc": {
+        "start": {
+          "line": 8,
+          "column": 5
+        },
+        "end": {
+          "line": 8,
+          "column": 6
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        243,
+        244
+      ],
+      "loc": {
+        "start": {
+          "line": 9,
+          "column": 2
+        },
+        "end": {
+          "line": 9,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "<",
+      "range": [
+        245,
+        246
+      ],
+      "loc": {
+        "start": {
+          "line": 10,
+          "column": 0
+        },
+        "end": {
+          "line": 10,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "/",
+      "range": [
+        246,
+        247
+      ],
+      "loc": {
+        "start": {
+          "line": 10,
+          "column": 1
+        },
+        "end": {
+          "line": 10,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "script",
+      "range": [
+        247,
+        253
+      ],
+      "loc": {
+        "start": {
+          "line": 10,
+          "column": 2
+        },
+        "end": {
+          "line": 10,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ">",
+      "range": [
+        253,
+        254
+      ],
+      "loc": {
+        "start": {
+          "line": 10,
+          "column": 8
+        },
+        "end": {
+          "line": 10,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": "HTMLText",
+      "value": "\n\n",
+      "range": [
+        254,
+        256
+      ],
+      "loc": {
+        "start": {
+          "line": 10,
+          "column": 9
+        },
+        "end": {
+          "line": 12,
+          "column": 0
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "<",
+      "range": [
+        256,
+        257
+      ],
+      "loc": {
+        "start": {
+          "line": 12,
+          "column": 0
+        },
+        "end": {
+          "line": 12,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "div",
+      "range": [
+        257,
+        260
+      ],
+      "loc": {
+        "start": {
+          "line": 12,
+          "column": 1
+        },
+        "end": {
+          "line": 12,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "use",
+      "range": [
+        263,
+        266
+      ],
+      "loc": {
+        "start": {
+          "line": 13,
+          "column": 2
+        },
+        "end": {
+          "line": 13,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ":",
+      "range": [
+        266,
+        267
+      ],
+      "loc": {
+        "start": {
+          "line": 13,
+          "column": 5
+        },
+        "end": {
+          "line": 13,
+          "column": 6
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "myAction",
+      "range": [
+        267,
+        275
+      ],
+      "loc": {
+        "start": {
+          "line": 13,
+          "column": 6
+        },
+        "end": {
+          "line": 13,
+          "column": 14
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "=",
+      "range": [
+        275,
+        276
+      ],
+      "loc": {
+        "start": {
+          "line": 13,
+          "column": 14
+        },
+        "end": {
+          "line": 13,
+          "column": 15
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        276,
+        277
+      ],
+      "loc": {
+        "start": {
+          "line": 13,
+          "column": 15
+        },
+        "end": {
+          "line": 13,
+          "column": 16
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "(",
+      "range": [
+        277,
+        278
+      ],
+      "loc": {
+        "start": {
+          "line": 13,
+          "column": 16
+        },
+        "end": {
+          "line": 13,
+          "column": 17
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ")",
+      "range": [
+        278,
+        279
+      ],
+      "loc": {
+        "start": {
+          "line": 13,
+          "column": 17
+        },
+        "end": {
+          "line": 13,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "=>",
+      "range": [
+        280,
+        282
+      ],
+      "loc": {
+        "start": {
+          "line": 13,
+          "column": 19
+        },
+        "end": {
+          "line": 13,
+          "column": 21
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        283,
+        284
+      ],
+      "loc": {
+        "start": {
+          "line": 13,
+          "column": 22
+        },
+        "end": {
+          "line": 13,
+          "column": 23
+        }
+      }
+    },
+    {
+      "type": "Keyword",
+      "value": "return",
+      "range": [
+        289,
+        295
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 4
+        },
+        "end": {
+          "line": 14,
+          "column": 10
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "(",
+      "range": [
+        296,
+        297
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 11
+        },
+        "end": {
+          "line": 14,
+          "column": 12
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "param",
+      "range": [
+        297,
+        302
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 12
+        },
+        "end": {
+          "line": 14,
+          "column": 17
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ")",
+      "range": [
+        302,
+        303
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 17
+        },
+        "end": {
+          "line": 14,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "=>",
+      "range": [
+        304,
+        306
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 19
+        },
+        "end": {
+          "line": 14,
+          "column": 21
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        307,
+        308
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 22
+        },
+        "end": {
+          "line": 14,
+          "column": 23
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "param",
+      "range": [
+        315,
+        320
+      ],
+      "loc": {
+        "start": {
+          "line": 15,
+          "column": 6
+        },
+        "end": {
+          "line": 15,
+          "column": 11
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ".",
+      "range": [
+        320,
+        321
+      ],
+      "loc": {
+        "start": {
+          "line": 15,
+          "column": 11
+        },
+        "end": {
+          "line": 15,
+          "column": 12
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "foo",
+      "range": [
+        321,
+        324
+      ],
+      "loc": {
+        "start": {
+          "line": 15,
+          "column": 12
+        },
+        "end": {
+          "line": 15,
+          "column": 15
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ";",
+      "range": [
+        324,
+        325
+      ],
+      "loc": {
+        "start": {
+          "line": 15,
+          "column": 15
+        },
+        "end": {
+          "line": 15,
+          "column": 16
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        330,
+        331
+      ],
+      "loc": {
+        "start": {
+          "line": 16,
+          "column": 4
+        },
+        "end": {
+          "line": 16,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ";",
+      "range": [
+        331,
+        332
+      ],
+      "loc": {
+        "start": {
+          "line": 16,
+          "column": 5
+        },
+        "end": {
+          "line": 16,
+          "column": 6
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        335,
+        336
+      ],
+      "loc": {
+        "start": {
+          "line": 17,
+          "column": 2
+        },
+        "end": {
+          "line": 17,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        336,
+        337
+      ],
+      "loc": {
+        "start": {
+          "line": 17,
+          "column": 3
+        },
+        "end": {
+          "line": 17,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "/",
+      "range": [
+        338,
+        339
+      ],
+      "loc": {
+        "start": {
+          "line": 18,
+          "column": 0
+        },
+        "end": {
+          "line": 18,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ">",
+      "range": [
+        339,
+        340
+      ],
+      "loc": {
+        "start": {
+          "line": 18,
+          "column": 1
+        },
+        "end": {
+          "line": 18,
+          "column": 2
+        }
+      }
+    }
+  ],
+  "range": [
+    0,
+    341
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 19,
+      "column": 0
+    }
+  }
+}

--- a/tests/fixtures/parser/ast/ts-use01-scope-output.json
+++ b/tests/fixtures/parser/ast/ts-use01-scope-output.json
@@ -1,0 +1,12538 @@
+{
+  "type": "global",
+  "variables": [
+    {
+      "name": "ClassMemberDecoratorContext",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DecoratorContext",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ClassDecoratorContext",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ClassMethodDecoratorContext",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ClassGetterDecoratorContext",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ClassSetterDecoratorContext",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ClassAccessorDecoratorContext",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ClassAccessorDecoratorTarget",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ClassAccessorDecoratorResult",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ClassFieldDecoratorContext",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ClassDecorator",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PropertyDecorator",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MethodDecorator",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ParameterDecorator",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Symbol",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PropertyKey",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PropertyDescriptor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PropertyDescriptorMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Object",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ObjectConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Function",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FunctionConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ThisParameterType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OmitThisParameter",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CallableFunction",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NewableFunction",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IArguments",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "String",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "StringConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Boolean",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "BooleanConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Number",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NumberConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TemplateStringsArray",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ImportMeta",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ImportCallOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ImportAssertions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Math",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Date",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DateConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RegExpMatchArray",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RegExpExecArray",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RegExp",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RegExpConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Error",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ErrorConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EvalError",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EvalErrorConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RangeError",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RangeErrorConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReferenceError",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReferenceErrorConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SyntaxError",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SyntaxErrorConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TypeError",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TypeErrorConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "URIError",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "URIErrorConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "JSON",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReadonlyArray",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ConcatArray",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Array",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ArrayConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TypedPropertyDescriptor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PromiseConstructorLike",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PromiseLike",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Promise",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Awaited",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ArrayLike",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Partial",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Required",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Readonly",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Pick",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Record",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Exclude",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Extract",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Omit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NonNullable",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Parameters",
+      "identifiers": [],
+      "defs": [],
+      "references": [
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "Parameters",
+            "range": [
+              341,
+              351
+            ],
+            "loc": {
+              "start": {
+                "line": 19,
+                "column": 0
+              },
+              "end": {
+                "line": 19,
+                "column": 10
+              }
+            }
+          },
+          "from": "module",
+          "init": null,
+          "resolved": null
+        }
+      ]
+    },
+    {
+      "name": "ConstructorParameters",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReturnType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "InstanceType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Uppercase",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Lowercase",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Capitalize",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Uncapitalize",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ThisType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ArrayBuffer",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ArrayBufferTypes",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ArrayBufferLike",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ArrayBufferConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ArrayBufferView",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DataView",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DataViewConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Int8Array",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Int8ArrayConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Uint8Array",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Uint8ArrayConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Uint8ClampedArray",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Uint8ClampedArrayConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Int16Array",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Int16ArrayConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Uint16Array",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Uint16ArrayConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Int32Array",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Int32ArrayConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Uint32Array",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Uint32ArrayConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Float32Array",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Float32ArrayConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Float64Array",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Float64ArrayConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Intl",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AddEventListenerOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AesCbcParams",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AesCtrParams",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AesDerivedKeyParams",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AesGcmParams",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AesKeyAlgorithm",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AesKeyGenParams",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Algorithm",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AnalyserOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AnimationEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AnimationPlaybackEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AssignedNodesOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioBufferOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioBufferSourceOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioConfiguration",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioContextOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioNodeOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioProcessingEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioTimestamp",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioWorkletNodeOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AuthenticationExtensionsClientInputs",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AuthenticationExtensionsClientOutputs",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AuthenticatorSelectionCriteria",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "BiquadFilterOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "BlobEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "BlobPropertyBag",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSStyleSheetInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CacheQueryOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasRenderingContext2DSettings",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ChannelMergerOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ChannelSplitterOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CheckVisibilityOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ClientQueryOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ClipboardEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ClipboardItemOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CloseEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CompositionEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ComputedEffectTiming",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ComputedKeyframe",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ConstantSourceOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ConstrainBooleanParameters",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ConstrainDOMStringParameters",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ConstrainDoubleRange",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ConstrainULongRange",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ConvolverOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CredentialCreationOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CredentialPropertiesOutput",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CredentialRequestOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CryptoKeyPair",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CustomEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMMatrix2DInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMMatrixInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMPointInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMQuadInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMRectInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DelayOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DeviceMotionEventAccelerationInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DeviceMotionEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DeviceMotionEventRotationRateInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DeviceOrientationEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DisplayMediaStreamOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DocumentTimelineOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DoubleRange",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DragEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DynamicsCompressorOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EcKeyAlgorithm",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EcKeyGenParams",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EcKeyImportParams",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EcdhKeyDeriveParams",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EcdsaParams",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EffectTiming",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ElementCreationOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ElementDefinitionOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ErrorEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EventListenerOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EventModifierInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EventSourceInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FilePropertyBag",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FileSystemFlags",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FileSystemGetDirectoryOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FileSystemGetFileOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FileSystemRemoveOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FocusEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FocusOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FontFaceDescriptors",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FontFaceSetLoadEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FormDataEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FullscreenOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GainOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GamepadEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GetAnimationsOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GetNotificationOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GetRootNodeOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HashChangeEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HkdfParams",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HmacImportParams",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HmacKeyAlgorithm",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HmacKeyGenParams",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBDatabaseInfo",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBIndexParameters",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBObjectStoreParameters",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBTransactionOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBVersionChangeEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IIRFilterOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IdleRequestOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ImageBitmapOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ImageBitmapRenderingContextSettings",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ImageDataSettings",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ImageEncodeOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "InputEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IntersectionObserverEntryInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IntersectionObserverInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "JsonWebKey",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "KeyAlgorithm",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "KeyboardEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Keyframe",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "KeyframeAnimationOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "KeyframeEffectOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "LockInfo",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "LockManagerSnapshot",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "LockOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MIDIConnectionEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MIDIMessageEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MIDIOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaCapabilitiesDecodingInfo",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaCapabilitiesEncodingInfo",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaCapabilitiesInfo",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaConfiguration",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaDecodingConfiguration",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaElementAudioSourceOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaEncodingConfiguration",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaEncryptedEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaImage",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaKeyMessageEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaKeySystemConfiguration",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaKeySystemMediaCapability",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaMetadataInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaPositionState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaQueryListEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaRecorderOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaSessionActionDetails",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaStreamAudioSourceOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaStreamConstraints",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaStreamTrackEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaTrackCapabilities",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaTrackConstraintSet",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaTrackConstraints",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaTrackSettings",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaTrackSupportedConstraints",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MessageEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MouseEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MultiCacheQueryOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MutationObserverInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NavigationPreloadState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NotificationAction",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NotificationOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OfflineAudioCompletionEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OfflineAudioContextOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OptionalEffectTiming",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OscillatorOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PageTransitionEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PannerOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PaymentCurrencyAmount",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PaymentDetailsBase",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PaymentDetailsInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PaymentDetailsModifier",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PaymentDetailsUpdate",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PaymentItem",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PaymentMethodChangeEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PaymentMethodData",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PaymentRequestUpdateEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PaymentValidationErrors",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Pbkdf2Params",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PerformanceMarkOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PerformanceMeasureOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PerformanceObserverInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PeriodicWaveConstraints",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PeriodicWaveOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PermissionDescriptor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PictureInPictureEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PointerEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PopStateEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PositionOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ProgressEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PromiseRejectionEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PropertyIndexedKeyframes",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PublicKeyCredentialCreationOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PublicKeyCredentialDescriptor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PublicKeyCredentialEntity",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PublicKeyCredentialParameters",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PublicKeyCredentialRequestOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PublicKeyCredentialRpEntity",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PublicKeyCredentialUserEntity",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PushSubscriptionJSON",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PushSubscriptionOptionsInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "QueuingStrategy",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "QueuingStrategyInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCAnswerOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCCertificateExpiration",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCConfiguration",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCDTMFToneChangeEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCDataChannelEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCDataChannelInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCDtlsFingerprint",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCEncodedAudioFrameMetadata",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCEncodedVideoFrameMetadata",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCErrorEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCErrorInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCIceCandidateInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCIceCandidatePairStats",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCIceServer",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCInboundRtpStreamStats",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCLocalSessionDescriptionInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCOfferAnswerOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCOfferOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCOutboundRtpStreamStats",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCPeerConnectionIceErrorEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCPeerConnectionIceEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCReceivedRtpStreamStats",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCRtcpParameters",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCRtpCapabilities",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCRtpCodecCapability",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCRtpCodecParameters",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCRtpCodingParameters",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCRtpContributingSource",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCRtpEncodingParameters",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCRtpHeaderExtensionCapability",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCRtpHeaderExtensionParameters",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCRtpParameters",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCRtpReceiveParameters",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCRtpSendParameters",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCRtpStreamStats",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCRtpSynchronizationSource",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCRtpTransceiverInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCSentRtpStreamStats",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCSessionDescriptionInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCStats",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCTrackEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCTransportStats",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReadableStreamGetReaderOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReadableStreamReadDoneResult",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReadableStreamReadValueResult",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReadableWritablePair",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RegistrationOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RequestInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ResizeObserverOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ResponseInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RsaHashedImportParams",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RsaHashedKeyAlgorithm",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RsaHashedKeyGenParams",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RsaKeyAlgorithm",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RsaKeyGenParams",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RsaOaepParams",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RsaOtherPrimesInfo",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RsaPssParams",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGBoundingBoxOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ScrollIntoViewOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ScrollOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ScrollToOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SecurityPolicyViolationEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ShadowRootInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ShareData",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SpeechSynthesisErrorEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SpeechSynthesisEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "StaticRangeInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "StereoPannerOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "StorageEstimate",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "StorageEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "StreamPipeOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "StructuredSerializeOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SubmitEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextDecodeOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextDecoderOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextEncoderEncodeIntoResult",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TouchEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TouchInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TrackEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Transformer",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TransitionEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "UIEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ULongRange",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "UnderlyingByteSource",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "UnderlyingDefaultSource",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "UnderlyingSink",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "UnderlyingSource",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ValidityStateFlags",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "VideoColorSpaceInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "VideoConfiguration",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "VideoFrameCallbackMetadata",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WaveShaperOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLContextAttributes",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLContextEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WheelEventInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WindowPostMessageOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WorkerOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WorkletOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NodeFilter",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "XPathNSResolver",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ANGLE_instanced_arrays",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ARIAMixin",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AbortController",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AbortSignalEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AbortSignal",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AbstractRange",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AbstractWorkerEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AbstractWorker",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AnalyserNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Animatable",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AnimationEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Animation",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AnimationEffect",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AnimationEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AnimationFrameProvider",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AnimationPlaybackEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AnimationTimeline",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Attr",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioBuffer",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioBufferSourceNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioContext",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioDestinationNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioListener",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioParam",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioParamMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioProcessingEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioScheduledSourceNodeEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioScheduledSourceNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioWorklet",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioWorkletNodeEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioWorkletNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AuthenticatorAssertionResponse",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AuthenticatorAttestationResponse",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AuthenticatorResponse",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "BarProp",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "BaseAudioContextEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "BaseAudioContext",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "BeforeUnloadEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "BiquadFilterNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Blob",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "BlobEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Body",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "BroadcastChannelEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "BroadcastChannel",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ByteLengthQueuingStrategy",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CDATASection",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSAnimation",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSConditionRule",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSContainerRule",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSCounterStyleRule",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSFontFaceRule",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSFontFeatureValuesRule",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSFontPaletteValuesRule",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSGroupingRule",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSImportRule",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSKeyframeRule",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSKeyframesRule",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSLayerBlockRule",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSLayerStatementRule",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSMediaRule",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSNamespaceRule",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSPageRule",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSRule",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSRuleList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSStyleDeclaration",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSStyleRule",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSStyleSheet",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSSupportsRule",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSTransition",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Cache",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CacheStorage",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasCaptureMediaStreamTrack",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasCompositing",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasDrawImage",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasDrawPath",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasFillStrokeStyles",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasFilters",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasGradient",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasImageData",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasImageSmoothing",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasPath",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasPathDrawingStyles",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasPattern",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasRect",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasRenderingContext2D",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasShadowStyles",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasText",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasTextDrawingStyles",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasTransform",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasUserInterface",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ChannelMergerNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ChannelSplitterNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CharacterData",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ChildNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ClientRect",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Clipboard",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ClipboardEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ClipboardItem",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CloseEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Comment",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CompositionEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ConstantSourceNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ConvolverNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CountQueuingStrategy",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Credential",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CredentialsContainer",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Crypto",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CryptoKey",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CustomElementRegistry",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CustomEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMException",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMImplementation",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMMatrix",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGMatrix",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebKitCSSMatrix",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMMatrixReadOnly",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMParser",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMPoint",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGPoint",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMPointReadOnly",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMQuad",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMRect",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGRect",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMRectList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMRectReadOnly",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMStringList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMStringMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMTokenList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DataTransfer",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DataTransferItem",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DataTransferItemList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DelayNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DeviceMotionEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DeviceMotionEventAcceleration",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DeviceMotionEventRotationRate",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DeviceOrientationEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DocumentEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Document",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DocumentFragment",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DocumentOrShadowRoot",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DocumentTimeline",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DocumentType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DragEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DynamicsCompressorNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EXT_blend_minmax",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EXT_color_buffer_float",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EXT_color_buffer_half_float",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EXT_float_blend",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EXT_frag_depth",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EXT_sRGB",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EXT_shader_texture_lod",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EXT_texture_compression_bptc",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EXT_texture_compression_rgtc",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EXT_texture_filter_anisotropic",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EXT_texture_norm16",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ElementEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Element",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ElementCSSInlineStyle",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ElementContentEditable",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ElementInternals",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ErrorEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Event",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EventCounts",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EventListener",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EventListenerObject",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EventSourceEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EventSource",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EventTarget",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "External",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "File",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FileList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FileReaderEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FileReader",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FileSystem",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FileSystemDirectoryEntry",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FileSystemDirectoryHandle",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FileSystemDirectoryReader",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FileSystemEntry",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FileSystemFileEntry",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FileSystemFileHandle",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FileSystemHandle",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FocusEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FontFace",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FontFaceSetEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FontFaceSet",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FontFaceSetLoadEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FontFaceSource",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FormData",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FormDataEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GainNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Gamepad",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GamepadButton",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GamepadEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GamepadHapticActuator",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GenericTransformStream",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Geolocation",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GeolocationCoordinates",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GeolocationPosition",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GeolocationPositionError",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GlobalEventHandlersEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GlobalEventHandlers",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLAllCollection",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLAnchorElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLAreaElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLAudioElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLBRElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLBaseElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLBodyElementEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLBodyElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLButtonElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLCanvasElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLCollectionBase",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLCollection",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLCollectionOf",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLDListElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLDataElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLDataListElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLDetailsElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLDialogElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLDirectoryElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLDivElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLDocument",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLElementEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLElement",
+      "identifiers": [],
+      "defs": [],
+      "references": [
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "HTMLElement",
+            "range": [
+              105,
+              116
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 27
+              },
+              "end": {
+                "line": 3,
+                "column": 38
+              }
+            }
+          },
+          "from": "function",
+          "init": null,
+          "resolved": null
+        }
+      ]
+    },
+    {
+      "name": "HTMLEmbedElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLFieldSetElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLFontElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLFormControlsCollection",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLFormElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLFrameElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLFrameSetElementEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLFrameSetElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLHRElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLHeadElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLHeadingElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLHtmlElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLHyperlinkElementUtils",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLIFrameElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLImageElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLInputElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLLIElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLLabelElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLLegendElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLLinkElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLMapElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLMarqueeElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLMediaElementEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLMediaElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLMenuElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLMetaElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLMeterElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLModElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLOListElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLObjectElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLOptGroupElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLOptionElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLOptionsCollection",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLOrSVGElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLOutputElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLParagraphElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLParamElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLPictureElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLPreElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLProgressElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLQuoteElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLScriptElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLSelectElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLSlotElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLSourceElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLSpanElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLStyleElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLTableCaptionElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLTableCellElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLTableColElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLTableDataCellElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLTableElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLTableHeaderCellElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLTableRowElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLTableSectionElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLTemplateElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLTextAreaElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLTimeElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLTitleElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLTrackElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLUListElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLUnknownElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLVideoElementEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLVideoElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HashChangeEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Headers",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "History",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBCursor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBCursorWithValue",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBDatabaseEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBDatabase",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBFactory",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBIndex",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBKeyRange",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBObjectStore",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBOpenDBRequestEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBOpenDBRequest",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBRequestEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBRequest",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBTransactionEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBTransaction",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBVersionChangeEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IIRFilterNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IdleDeadline",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ImageBitmap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ImageBitmapRenderingContext",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ImageData",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "InnerHTML",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "InputDeviceInfo",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "InputEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IntersectionObserver",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IntersectionObserverEntry",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "KHR_parallel_shader_compile",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "KeyboardEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "KeyframeEffect",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "LinkStyle",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Location",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Lock",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "LockManager",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MIDIAccessEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MIDIAccess",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MIDIConnectionEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MIDIInputEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MIDIInput",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MIDIInputMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MIDIMessageEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MIDIOutput",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MIDIOutputMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MIDIPortEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MIDIPort",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MathMLElementEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MathMLElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaCapabilities",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaDeviceInfo",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaDevicesEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaDevices",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaElementAudioSourceNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaEncryptedEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaError",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaKeyMessageEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaKeySessionEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaKeySession",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaKeyStatusMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaKeySystemAccess",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaKeys",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaMetadata",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaQueryListEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaQueryList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaQueryListEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaRecorderEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaRecorder",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaSession",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaSourceEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaSource",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaStreamEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaStream",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaStreamAudioDestinationNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaStreamAudioSourceNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaStreamTrackEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaStreamTrack",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaStreamTrackEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MessageChannel",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MessageEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MessagePortEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MessagePort",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MimeType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MimeTypeArray",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MouseEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MutationEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MutationObserver",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MutationRecord",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NamedNodeMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NavigationPreloadManager",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Navigator",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NavigatorAutomationInformation",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NavigatorConcurrentHardware",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NavigatorContentUtils",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NavigatorCookies",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NavigatorID",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NavigatorLanguage",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NavigatorLocks",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NavigatorOnLine",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NavigatorPlugins",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NavigatorStorage",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Node",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NodeIterator",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NodeList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NodeListOf",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NonDocumentTypeChildNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NonElementParentNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NotificationEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Notification",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OES_draw_buffers_indexed",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OES_element_index_uint",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OES_fbo_render_mipmap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OES_standard_derivatives",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OES_texture_float",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OES_texture_float_linear",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OES_texture_half_float",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OES_texture_half_float_linear",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OES_vertex_array_object",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OVR_multiview2",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OfflineAudioCompletionEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OfflineAudioContextEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OfflineAudioContext",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OffscreenCanvasEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OffscreenCanvas",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OffscreenCanvasRenderingContext2D",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OscillatorNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OverconstrainedError",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PageTransitionEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PannerNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ParentNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Path2D",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PaymentMethodChangeEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PaymentRequestEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PaymentRequest",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PaymentRequestUpdateEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PaymentResponse",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PerformanceEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Performance",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PerformanceEntry",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PerformanceEventTiming",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PerformanceMark",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PerformanceMeasure",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PerformanceNavigation",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PerformanceNavigationTiming",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PerformanceObserver",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PerformanceObserverEntryList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PerformancePaintTiming",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PerformanceResourceTiming",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PerformanceServerTiming",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PerformanceTiming",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PeriodicWave",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PermissionStatusEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PermissionStatus",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Permissions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PictureInPictureEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PictureInPictureWindowEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PictureInPictureWindow",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Plugin",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PluginArray",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PointerEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PopStateEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ProcessingInstruction",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ProgressEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PromiseRejectionEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PublicKeyCredential",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PushManager",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PushSubscription",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PushSubscriptionOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCCertificate",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCDTMFSenderEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCDTMFSender",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCDTMFToneChangeEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCDataChannelEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCDataChannel",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCDataChannelEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCDtlsTransportEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCDtlsTransport",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCEncodedAudioFrame",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCEncodedVideoFrame",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCError",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCErrorEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCIceCandidate",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCIceTransportEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCIceTransport",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCPeerConnectionEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCPeerConnection",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCPeerConnectionIceErrorEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCPeerConnectionIceEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCRtpReceiver",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCRtpSender",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCRtpTransceiver",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCSctpTransportEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCSctpTransport",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCSessionDescription",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCStatsReport",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCTrackEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RadioNodeList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Range",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReadableByteStreamController",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReadableStream",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReadableStreamBYOBReader",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReadableStreamBYOBRequest",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReadableStreamDefaultController",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReadableStreamDefaultReader",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReadableStreamGenericReader",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RemotePlaybackEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RemotePlayback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Request",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ResizeObserver",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ResizeObserverEntry",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ResizeObserverSize",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Response",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGAElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGAngle",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGAnimateElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGAnimateMotionElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGAnimateTransformElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGAnimatedAngle",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGAnimatedBoolean",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGAnimatedEnumeration",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGAnimatedInteger",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGAnimatedLength",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGAnimatedLengthList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGAnimatedNumber",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGAnimatedNumberList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGAnimatedPoints",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGAnimatedPreserveAspectRatio",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGAnimatedRect",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGAnimatedString",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGAnimatedTransformList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGAnimationElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGCircleElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGClipPathElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGComponentTransferFunctionElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGDefsElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGDescElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGElementEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGEllipseElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFEBlendElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFEColorMatrixElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFEComponentTransferElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFECompositeElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFEConvolveMatrixElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFEDiffuseLightingElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFEDisplacementMapElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFEDistantLightElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFEDropShadowElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFEFloodElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFEFuncAElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFEFuncBElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFEFuncGElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFEFuncRElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFEGaussianBlurElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFEImageElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFEMergeElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFEMergeNodeElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFEMorphologyElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFEOffsetElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFEPointLightElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFESpecularLightingElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFESpotLightElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFETileElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFETurbulenceElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFilterElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFilterPrimitiveStandardAttributes",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGFitToViewBox",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGForeignObjectElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGGElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGGeometryElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGGradientElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGGraphicsElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGImageElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGLength",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGLengthList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGLineElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGLinearGradientElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGMPathElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGMarkerElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGMaskElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGMetadataElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGNumber",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGNumberList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGPathElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGPatternElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGPointList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGPolygonElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGPolylineElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGPreserveAspectRatio",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGRadialGradientElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGRectElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGSVGElementEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGSVGElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGScriptElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGSetElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGStopElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGStringList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGStyleElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGSwitchElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGSymbolElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGTSpanElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGTests",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGTextContentElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGTextElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGTextPathElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGTextPositioningElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGTitleElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGTransform",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGTransformList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGURIReference",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGUnitTypes",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGUseElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGViewElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Screen",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ScreenOrientationEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ScreenOrientation",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ScriptProcessorNodeEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ScriptProcessorNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SecurityPolicyViolationEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Selection",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ServiceWorkerEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ServiceWorker",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ServiceWorkerContainerEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ServiceWorkerContainer",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ServiceWorkerRegistrationEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ServiceWorkerRegistration",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ShadowRootEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ShadowRoot",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SharedWorker",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Slottable",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SourceBufferEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SourceBuffer",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SourceBufferListEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SourceBufferList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SpeechRecognitionAlternative",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SpeechRecognitionResult",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SpeechRecognitionResultList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SpeechSynthesisEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SpeechSynthesis",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SpeechSynthesisErrorEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SpeechSynthesisEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SpeechSynthesisUtteranceEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SpeechSynthesisUtterance",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SpeechSynthesisVoice",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "StaticRange",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "StereoPannerNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Storage",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "StorageEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "StorageManager",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "StyleMedia",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "StyleSheet",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "StyleSheetList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SubmitEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SubtleCrypto",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Text",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextDecoder",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextDecoderCommon",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextDecoderStream",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextEncoder",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextEncoderCommon",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextEncoderStream",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextMetrics",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextTrackEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextTrack",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextTrackCueEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextTrackCue",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextTrackCueList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextTrackListEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextTrackList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TimeRanges",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Touch",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TouchEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TouchList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TrackEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TransformStream",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TransformStreamDefaultController",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TransitionEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TreeWalker",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "UIEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "URL",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "webkitURL",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "URLSearchParams",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "VTTCue",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "VTTRegion",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ValidityState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "VideoColorSpace",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "VideoPlaybackQuality",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "VisualViewportEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "VisualViewport",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WEBGL_color_buffer_float",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WEBGL_compressed_texture_astc",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WEBGL_compressed_texture_etc",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WEBGL_compressed_texture_etc1",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WEBGL_compressed_texture_s3tc",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WEBGL_compressed_texture_s3tc_srgb",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WEBGL_debug_renderer_info",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WEBGL_debug_shaders",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WEBGL_depth_texture",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WEBGL_draw_buffers",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WEBGL_lose_context",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WEBGL_multi_draw",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WaveShaperNode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGL2RenderingContext",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGL2RenderingContextBase",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGL2RenderingContextOverloads",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLActiveInfo",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLBuffer",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLContextEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLFramebuffer",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLProgram",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLQuery",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLRenderbuffer",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLRenderingContext",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLRenderingContextBase",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLRenderingContextOverloads",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLSampler",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLShader",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLShaderPrecisionFormat",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLSync",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLTexture",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLTransformFeedback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLUniformLocation",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLVertexArrayObject",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLVertexArrayObjectOES",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebSocketEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebSocket",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WheelEvent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WindowEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Window",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WindowEventHandlersEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WindowEventHandlers",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WindowLocalStorage",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WindowOrWorkerGlobalScope",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WindowSessionStorage",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WorkerEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Worker",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Worklet",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WritableStream",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WritableStreamDefaultController",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WritableStreamDefaultWriter",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "XMLDocument",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "XMLHttpRequestEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "XMLHttpRequest",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "XMLHttpRequestEventTargetEventMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "XMLHttpRequestEventTarget",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "XMLHttpRequestUpload",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "XMLSerializer",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "XPathEvaluator",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "XPathEvaluatorBase",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "XPathExpression",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "XPathResult",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "XSLTProcessor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Console",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSS",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebAssembly",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "BlobCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CustomElementConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DecodeErrorCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DecodeSuccessCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ErrorCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FileCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FileSystemEntriesCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FileSystemEntryCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FrameRequestCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FunctionStringCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IdleRequestCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IntersectionObserverCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "LockGrantedCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaSessionActionHandler",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MutationCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NotificationPermissionCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OnBeforeUnloadEventHandlerNonNull",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OnErrorEventHandlerNonNull",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PerformanceObserverCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PositionCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PositionErrorCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "QueuingStrategySize",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCPeerConnectionErrorCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCSessionDescriptionCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RemotePlaybackAvailabilityCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ResizeObserverCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TransformerFlushCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TransformerStartCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TransformerTransformCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "UnderlyingSinkAbortCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "UnderlyingSinkCloseCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "UnderlyingSinkStartCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "UnderlyingSinkWriteCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "UnderlyingSourceCancelCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "UnderlyingSourcePullCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "UnderlyingSourceStartCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "VideoFrameRequestCallback",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "VoidFunction",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLElementTagNameMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLElementDeprecatedTagNameMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SVGElementTagNameMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MathMLElementTagNameMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ElementTagNameMap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AlgorithmIdentifier",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "BigInteger",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "BinaryData",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "BlobPart",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "BodyInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "BufferSource",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "COSEAlgorithmIdentifier",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CSSNumberish",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasImageSource",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ClipboardItemData",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ClipboardItems",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ConstrainBoolean",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ConstrainDOMString",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ConstrainDouble",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ConstrainULong",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMHighResTimeStamp",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EpochTimeStamp",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EventListenerOrEventListenerObject",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Float32List",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FormDataEntryValue",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GLbitfield",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GLboolean",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GLclampf",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GLenum",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GLfloat",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GLint",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GLint64",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GLintptr",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GLsizei",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GLsizeiptr",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GLuint",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GLuint64",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLOrSVGImageElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HTMLOrSVGScriptElement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HashAlgorithmIdentifier",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HeadersInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBValidKey",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ImageBitmapSource",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Int32List",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "LineAndPositionSetting",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaProvider",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MessageEventSource",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MutationRecordType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NamedCurve",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OffscreenRenderingContext",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OnBeforeUnloadEventHandler",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OnErrorEventHandler",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PerformanceEntryList",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReadableStreamController",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReadableStreamReadResult",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReadableStreamReader",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RenderingContext",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RequestInfo",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TexImageSource",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TimerHandler",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Transferable",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Uint32List",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "VibratePattern",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WindowProxy",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "XMLHttpRequestBodyInit",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AlignSetting",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AnimationPlayState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AnimationReplaceState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AppendMode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AttestationConveyancePreference",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioContextLatencyCategory",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AudioContextState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AuthenticatorAttachment",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AuthenticatorTransport",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AutoKeyword",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "AutomationRate",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "BinaryType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "BiquadFilterType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanPlayTypeResult",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasDirection",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasFillRule",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasFontKerning",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasFontStretch",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasFontVariantCaps",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasLineCap",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasLineJoin",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasTextAlign",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasTextBaseline",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CanvasTextRendering",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ChannelCountMode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ChannelInterpretation",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ClientTypes",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ColorGamut",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ColorSpaceConversion",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CompositeOperation",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CompositeOperationOrAuto",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "CredentialMediationRequirement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DOMParserSupportedType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DirectionSetting",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DisplayCaptureSurfaceType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DistanceModelType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DocumentReadyState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "DocumentVisibilityState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EndOfStreamError",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EndingType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FileSystemHandleKind",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FillMode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FontDisplay",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FontFaceLoadStatus",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FontFaceSetLoadStatus",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "FullscreenNavigationUI",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GamepadHapticActuatorType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GamepadMappingType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "GlobalCompositeOperation",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "HdrMetadataType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBCursorDirection",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBRequestReadyState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBTransactionDurability",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IDBTransactionMode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ImageOrientation",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ImageSmoothingQuality",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "InsertPosition",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "IterationCompositeOperation",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "KeyFormat",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "KeyType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "KeyUsage",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "LineAlignSetting",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "LockMode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MIDIPortConnectionState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MIDIPortDeviceState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MIDIPortType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaDecodingType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaDeviceKind",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaEncodingType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaKeyMessageType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaKeySessionClosedReason",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaKeySessionType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaKeyStatus",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaKeysRequirement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaSessionAction",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaSessionPlaybackState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "MediaStreamTrackState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NavigationTimingType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NotificationDirection",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "NotificationPermission",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OffscreenRenderingContextId",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OrientationLockType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OrientationType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OscillatorType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "OverSampleType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PanningModelType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PaymentComplete",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PermissionName",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PermissionState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PlaybackDirection",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PositionAlignSetting",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PredefinedColorSpace",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PremultiplyAlpha",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PresentationStyle",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PublicKeyCredentialType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "PushEncryptionKeyName",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCBundlePolicy",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCDataChannelState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCDegradationPreference",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCDtlsTransportState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCEncodedVideoFrameType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCErrorDetailType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCIceCandidateType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCIceComponent",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCIceConnectionState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCIceGathererState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCIceGatheringState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCIceProtocol",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCIceTcpCandidateType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCIceTransportPolicy",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCIceTransportState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCPeerConnectionState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCPriorityType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCRtcpMuxPolicy",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCRtpTransceiverDirection",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCSctpTransportState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCSdpType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCSignalingState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCStatsIceCandidatePairState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RTCStatsType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReadableStreamReaderMode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReadableStreamType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReadyState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RecordingState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ReferrerPolicy",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RemotePlaybackState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RequestCache",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RequestCredentials",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RequestDestination",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RequestMode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "RequestRedirect",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ResidentKeyRequirement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ResizeObserverBoxOptions",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ResizeQuality",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ResponseType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ScrollBehavior",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ScrollLogicalPosition",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ScrollRestoration",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ScrollSetting",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SecurityPolicyViolationEventDisposition",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SelectionMode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ServiceWorkerState",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ServiceWorkerUpdateViaCache",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ShadowRootMode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SlotAssignmentMode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SpeechSynthesisErrorCode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextTrackKind",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextTrackMode",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TouchType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TransferFunction",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "UserVerificationRequirement",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "VideoColorPrimaries",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "VideoFacingModeEnum",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "VideoMatrixCoefficients",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "VideoTransferCharacteristics",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WebGLPowerPreference",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "WorkerType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "XMLHttpRequestResponseType",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ActiveXObject",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "ITextWriter",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextStreamBase",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextStreamWriter",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "TextStreamReader",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "SafeArray",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "Enumerator",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "EnumeratorConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "VBArray",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "VBArrayConstructor",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "VarDate",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "const",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$slots",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$props",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$restProps",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    }
+  ],
+  "references": [],
+  "childScopes": [
+    {
+      "type": "module",
+      "variables": [
+        {
+          "name": "MyActionParam",
+          "identifiers": [
+            {
+              "type": "Identifier",
+              "name": "MyActionParam",
+              "range": [
+                26,
+                39
+              ],
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 7
+                },
+                "end": {
+                  "line": 2,
+                  "column": 20
+                }
+              }
+            }
+          ],
+          "defs": [
+            {
+              "type": "Type",
+              "name": {
+                "type": "Identifier",
+                "name": "MyActionParam",
+                "range": [
+                  26,
+                  39
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 20
+                  }
+                }
+              },
+              "node": {
+                "type": "TSTypeAliasDeclaration",
+                "id": {
+                  "type": "Identifier",
+                  "name": "MyActionParam",
+                  "range": [
+                    26,
+                    39
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 20
+                    }
+                  }
+                },
+                "typeAnnotation": {
+                  "type": "TSFunctionType",
+                  "params": [],
+                  "returnType": {
+                    "type": "TSTypeAnnotation",
+                    "typeAnnotation": {
+                      "type": "TSFunctionType",
+                      "params": [
+                        {
+                          "type": "Identifier",
+                          "name": "p",
+                          "typeAnnotation": {
+                            "type": "TSTypeAnnotation",
+                            "typeAnnotation": {
+                              "type": "TSTypeLiteral",
+                              "members": [
+                                {
+                                  "type": "TSPropertySignature",
+                                  "computed": false,
+                                  "key": {
+                                    "type": "Identifier",
+                                    "name": "foo",
+                                    "range": [
+                                      54,
+                                      57
+                                    ],
+                                    "loc": {
+                                      "start": {
+                                        "line": 2,
+                                        "column": 35
+                                      },
+                                      "end": {
+                                        "line": 2,
+                                        "column": 38
+                                      }
+                                    }
+                                  },
+                                  "typeAnnotation": {
+                                    "type": "TSTypeAnnotation",
+                                    "typeAnnotation": {
+                                      "type": "TSNumberKeyword",
+                                      "range": [
+                                        59,
+                                        65
+                                      ],
+                                      "loc": {
+                                        "start": {
+                                          "line": 2,
+                                          "column": 40
+                                        },
+                                        "end": {
+                                          "line": 2,
+                                          "column": 46
+                                        }
+                                      }
+                                    },
+                                    "range": [
+                                      57,
+                                      65
+                                    ],
+                                    "loc": {
+                                      "start": {
+                                        "line": 2,
+                                        "column": 38
+                                      },
+                                      "end": {
+                                        "line": 2,
+                                        "column": 46
+                                      }
+                                    }
+                                  },
+                                  "range": [
+                                    54,
+                                    65
+                                  ],
+                                  "loc": {
+                                    "start": {
+                                      "line": 2,
+                                      "column": 35
+                                    },
+                                    "end": {
+                                      "line": 2,
+                                      "column": 46
+                                    }
+                                  }
+                                }
+                              ],
+                              "range": [
+                                52,
+                                67
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 2,
+                                  "column": 33
+                                },
+                                "end": {
+                                  "line": 2,
+                                  "column": 48
+                                }
+                              }
+                            },
+                            "range": [
+                              50,
+                              67
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 2,
+                                "column": 31
+                              },
+                              "end": {
+                                "line": 2,
+                                "column": 48
+                              }
+                            }
+                          },
+                          "range": [
+                            49,
+                            67
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 30
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 48
+                            }
+                          }
+                        }
+                      ],
+                      "returnType": {
+                        "type": "TSTypeAnnotation",
+                        "typeAnnotation": {
+                          "type": "TSVoidKeyword",
+                          "range": [
+                            72,
+                            76
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 53
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 57
+                            }
+                          }
+                        },
+                        "range": [
+                          69,
+                          76
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 50
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 57
+                          }
+                        }
+                      },
+                      "range": [
+                        48,
+                        76
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 29
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 57
+                        }
+                      }
+                    },
+                    "range": [
+                      45,
+                      76
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 26
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 57
+                      }
+                    }
+                  },
+                  "range": [
+                    42,
+                    76
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 23
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 57
+                    }
+                  }
+                },
+                "range": [
+                  21,
+                  77
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 58
+                  }
+                }
+              }
+            }
+          ],
+          "references": [
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "MyActionParam",
+                "range": [
+                  126,
+                  139
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 48
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 61
+                  }
+                }
+              },
+              "from": "function",
+              "init": null,
+              "resolved": {
+                "type": "Identifier",
+                "name": "MyActionParam",
+                "range": [
+                  26,
+                  39
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 20
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "myAction",
+          "identifiers": [
+            {
+              "type": "Identifier",
+              "name": "myAction",
+              "range": [
+                89,
+                97
+              ],
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 11
+                },
+                "end": {
+                  "line": 3,
+                  "column": 19
+                }
+              }
+            }
+          ],
+          "defs": [
+            {
+              "type": "FunctionName",
+              "name": {
+                "type": "Identifier",
+                "name": "myAction",
+                "range": [
+                  89,
+                  97
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 19
+                  }
+                }
+              },
+              "node": {
+                "type": "FunctionDeclaration",
+                "async": false,
+                "body": {
+                  "type": "BlockStatement",
+                  "body": [
+                    {
+                      "type": "VariableDeclaration",
+                      "kind": "const",
+                      "declarations": [
+                        {
+                          "type": "VariableDeclarator",
+                          "id": {
+                            "type": "Identifier",
+                            "name": "result",
+                            "range": [
+                              153,
+                              159
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 4,
+                                "column": 10
+                              },
+                              "end": {
+                                "line": 4,
+                                "column": 16
+                              }
+                            }
+                          },
+                          "init": {
+                            "type": "CallExpression",
+                            "arguments": [],
+                            "callee": {
+                              "type": "Identifier",
+                              "name": "params",
+                              "range": [
+                                162,
+                                168
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 4,
+                                  "column": 19
+                                },
+                                "end": {
+                                  "line": 4,
+                                  "column": 25
+                                }
+                              }
+                            },
+                            "optional": false,
+                            "range": [
+                              162,
+                              170
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 4,
+                                "column": 19
+                              },
+                              "end": {
+                                "line": 4,
+                                "column": 27
+                              }
+                            }
+                          },
+                          "range": [
+                            153,
+                            170
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 4,
+                              "column": 10
+                            },
+                            "end": {
+                              "line": 4,
+                              "column": 27
+                            }
+                          }
+                        }
+                      ],
+                      "range": [
+                        147,
+                        171
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 4
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 28
+                        }
+                      }
+                    },
+                    {
+                      "type": "ExpressionStatement",
+                      "expression": {
+                        "type": "CallExpression",
+                        "arguments": [
+                          {
+                            "type": "ObjectExpression",
+                            "properties": [
+                              {
+                                "type": "Property",
+                                "kind": "init",
+                                "computed": false,
+                                "key": {
+                                  "type": "Identifier",
+                                  "name": "foo",
+                                  "range": [
+                                    185,
+                                    188
+                                  ],
+                                  "loc": {
+                                    "start": {
+                                      "line": 5,
+                                      "column": 13
+                                    },
+                                    "end": {
+                                      "line": 5,
+                                      "column": 16
+                                    }
+                                  }
+                                },
+                                "method": false,
+                                "shorthand": false,
+                                "value": {
+                                  "type": "Literal",
+                                  "raw": "1",
+                                  "value": 1,
+                                  "range": [
+                                    190,
+                                    191
+                                  ],
+                                  "loc": {
+                                    "start": {
+                                      "line": 5,
+                                      "column": 18
+                                    },
+                                    "end": {
+                                      "line": 5,
+                                      "column": 19
+                                    }
+                                  }
+                                },
+                                "range": [
+                                  185,
+                                  191
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 5,
+                                    "column": 13
+                                  },
+                                  "end": {
+                                    "line": 5,
+                                    "column": 19
+                                  }
+                                }
+                              }
+                            ],
+                            "range": [
+                              183,
+                              193
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 5,
+                                "column": 11
+                              },
+                              "end": {
+                                "line": 5,
+                                "column": 21
+                              }
+                            }
+                          }
+                        ],
+                        "callee": {
+                          "type": "Identifier",
+                          "name": "result",
+                          "range": [
+                            176,
+                            182
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 5,
+                              "column": 4
+                            },
+                            "end": {
+                              "line": 5,
+                              "column": 10
+                            }
+                          }
+                        },
+                        "optional": false,
+                        "range": [
+                          176,
+                          194
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 5,
+                            "column": 4
+                          },
+                          "end": {
+                            "line": 5,
+                            "column": 22
+                          }
+                        }
+                      },
+                      "range": [
+                        176,
+                        195
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 5,
+                          "column": 4
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 23
+                        }
+                      }
+                    },
+                    {
+                      "type": "ReturnStatement",
+                      "argument": {
+                        "type": "ObjectExpression",
+                        "properties": [
+                          {
+                            "type": "Property",
+                            "kind": "init",
+                            "computed": false,
+                            "key": {
+                              "type": "Identifier",
+                              "name": "destroy",
+                              "range": [
+                                215,
+                                222
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 7,
+                                  "column": 6
+                                },
+                                "end": {
+                                  "line": 7,
+                                  "column": 13
+                                }
+                              }
+                            },
+                            "method": false,
+                            "shorthand": false,
+                            "value": {
+                              "type": "ArrowFunctionExpression",
+                              "async": false,
+                              "body": {
+                                "type": "BlockStatement",
+                                "body": [],
+                                "range": [
+                                  230,
+                                  232
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 7,
+                                    "column": 21
+                                  },
+                                  "end": {
+                                    "line": 7,
+                                    "column": 23
+                                  }
+                                }
+                              },
+                              "expression": false,
+                              "generator": false,
+                              "id": null,
+                              "params": [],
+                              "range": [
+                                224,
+                                232
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 7,
+                                  "column": 15
+                                },
+                                "end": {
+                                  "line": 7,
+                                  "column": 23
+                                }
+                              }
+                            },
+                            "range": [
+                              215,
+                              232
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 7,
+                                "column": 6
+                              },
+                              "end": {
+                                "line": 7,
+                                "column": 23
+                              }
+                            }
+                          }
+                        ],
+                        "range": [
+                          207,
+                          239
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 6,
+                            "column": 11
+                          },
+                          "end": {
+                            "line": 8,
+                            "column": 5
+                          }
+                        }
+                      },
+                      "range": [
+                        200,
+                        240
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 6,
+                          "column": 4
+                        },
+                        "end": {
+                          "line": 8,
+                          "column": 6
+                        }
+                      }
+                    }
+                  ],
+                  "range": [
+                    141,
+                    244
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 63
+                    },
+                    "end": {
+                      "line": 9,
+                      "column": 3
+                    }
+                  }
+                },
+                "expression": false,
+                "generator": false,
+                "id": {
+                  "type": "Identifier",
+                  "name": "myAction",
+                  "range": [
+                    89,
+                    97
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 19
+                    }
+                  }
+                },
+                "params": [
+                  {
+                    "type": "Identifier",
+                    "name": "_node",
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "typeAnnotation": {
+                        "type": "TSTypeReference",
+                        "typeName": {
+                          "type": "Identifier",
+                          "name": "HTMLElement",
+                          "range": [
+                            105,
+                            116
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 3,
+                              "column": 27
+                            },
+                            "end": {
+                              "line": 3,
+                              "column": 38
+                            }
+                          }
+                        },
+                        "range": [
+                          105,
+                          116
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 27
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 38
+                          }
+                        }
+                      },
+                      "range": [
+                        103,
+                        116
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 25
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 38
+                        }
+                      }
+                    },
+                    "range": [
+                      98,
+                      116
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 20
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 38
+                      }
+                    }
+                  },
+                  {
+                    "type": "Identifier",
+                    "name": "params",
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "typeAnnotation": {
+                        "type": "TSTypeReference",
+                        "typeName": {
+                          "type": "Identifier",
+                          "name": "MyActionParam",
+                          "range": [
+                            126,
+                            139
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 3,
+                              "column": 48
+                            },
+                            "end": {
+                              "line": 3,
+                              "column": 61
+                            }
+                          }
+                        },
+                        "range": [
+                          126,
+                          139
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 48
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 61
+                          }
+                        }
+                      },
+                      "range": [
+                        124,
+                        139
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 46
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 61
+                        }
+                      }
+                    },
+                    "range": [
+                      118,
+                      139
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 40
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 61
+                      }
+                    }
+                  }
+                ],
+                "range": [
+                  80,
+                  244
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 3
+                  }
+                }
+              }
+            }
+          ],
+          "references": [
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "myAction",
+                "range": [
+                  359,
+                  367
+                ],
+                "loc": {
+                  "start": {
+                    "line": 19,
+                    "column": 18
+                  },
+                  "end": {
+                    "line": 19,
+                    "column": 26
+                  }
+                }
+              },
+              "from": "module",
+              "init": null,
+              "resolved": {
+                "type": "Identifier",
+                "name": "myAction",
+                "range": [
+                  89,
+                  97
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 19
+                  }
+                }
+              }
+            },
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "myAction",
+                "range": [
+                  267,
+                  275
+                ],
+                "loc": {
+                  "start": {
+                    "line": 13,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 13,
+                    "column": 14
+                  }
+                }
+              },
+              "from": "module",
+              "init": null,
+              "resolved": {
+                "type": "Identifier",
+                "name": "myAction",
+                "range": [
+                  89,
+                  97
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 19
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "references": [
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "Parameters",
+            "range": [
+              341,
+              351
+            ],
+            "loc": {
+              "start": {
+                "line": 19,
+                "column": 0
+              },
+              "end": {
+                "line": 19,
+                "column": 10
+              }
+            }
+          },
+          "from": "module",
+          "init": null,
+          "resolved": null
+        },
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "myAction",
+            "range": [
+              359,
+              367
+            ],
+            "loc": {
+              "start": {
+                "line": 19,
+                "column": 18
+              },
+              "end": {
+                "line": 19,
+                "column": 26
+              }
+            }
+          },
+          "from": "module",
+          "init": null,
+          "resolved": {
+            "type": "Identifier",
+            "name": "myAction",
+            "range": [
+              89,
+              97
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 11
+              },
+              "end": {
+                "line": 3,
+                "column": 19
+              }
+            }
+          }
+        },
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "myAction",
+            "range": [
+              267,
+              275
+            ],
+            "loc": {
+              "start": {
+                "line": 13,
+                "column": 6
+              },
+              "end": {
+                "line": 13,
+                "column": 14
+              }
+            }
+          },
+          "from": "module",
+          "init": null,
+          "resolved": {
+            "type": "Identifier",
+            "name": "myAction",
+            "range": [
+              89,
+              97
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 11
+              },
+              "end": {
+                "line": 3,
+                "column": 19
+              }
+            }
+          }
+        }
+      ],
+      "childScopes": [
+        {
+          "type": "functionType",
+          "variables": [],
+          "references": [],
+          "childScopes": [
+            {
+              "type": "functionType",
+              "variables": [
+                {
+                  "name": "p",
+                  "identifiers": [
+                    {
+                      "type": "Identifier",
+                      "name": "p",
+                      "typeAnnotation": {
+                        "type": "TSTypeAnnotation",
+                        "typeAnnotation": {
+                          "type": "TSTypeLiteral",
+                          "members": [
+                            {
+                              "type": "TSPropertySignature",
+                              "computed": false,
+                              "key": {
+                                "type": "Identifier",
+                                "name": "foo",
+                                "range": [
+                                  54,
+                                  57
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 2,
+                                    "column": 35
+                                  },
+                                  "end": {
+                                    "line": 2,
+                                    "column": 38
+                                  }
+                                }
+                              },
+                              "typeAnnotation": {
+                                "type": "TSTypeAnnotation",
+                                "typeAnnotation": {
+                                  "type": "TSNumberKeyword",
+                                  "range": [
+                                    59,
+                                    65
+                                  ],
+                                  "loc": {
+                                    "start": {
+                                      "line": 2,
+                                      "column": 40
+                                    },
+                                    "end": {
+                                      "line": 2,
+                                      "column": 46
+                                    }
+                                  }
+                                },
+                                "range": [
+                                  57,
+                                  65
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 2,
+                                    "column": 38
+                                  },
+                                  "end": {
+                                    "line": 2,
+                                    "column": 46
+                                  }
+                                }
+                              },
+                              "range": [
+                                54,
+                                65
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 2,
+                                  "column": 35
+                                },
+                                "end": {
+                                  "line": 2,
+                                  "column": 46
+                                }
+                              }
+                            }
+                          ],
+                          "range": [
+                            52,
+                            67
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 33
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 48
+                            }
+                          }
+                        },
+                        "range": [
+                          50,
+                          67
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 31
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 48
+                          }
+                        }
+                      },
+                      "range": [
+                        49,
+                        67
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 30
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 48
+                        }
+                      }
+                    }
+                  ],
+                  "defs": [
+                    {
+                      "type": "Parameter",
+                      "name": {
+                        "type": "Identifier",
+                        "name": "p",
+                        "typeAnnotation": {
+                          "type": "TSTypeAnnotation",
+                          "typeAnnotation": {
+                            "type": "TSTypeLiteral",
+                            "members": [
+                              {
+                                "type": "TSPropertySignature",
+                                "computed": false,
+                                "key": {
+                                  "type": "Identifier",
+                                  "name": "foo",
+                                  "range": [
+                                    54,
+                                    57
+                                  ],
+                                  "loc": {
+                                    "start": {
+                                      "line": 2,
+                                      "column": 35
+                                    },
+                                    "end": {
+                                      "line": 2,
+                                      "column": 38
+                                    }
+                                  }
+                                },
+                                "typeAnnotation": {
+                                  "type": "TSTypeAnnotation",
+                                  "typeAnnotation": {
+                                    "type": "TSNumberKeyword",
+                                    "range": [
+                                      59,
+                                      65
+                                    ],
+                                    "loc": {
+                                      "start": {
+                                        "line": 2,
+                                        "column": 40
+                                      },
+                                      "end": {
+                                        "line": 2,
+                                        "column": 46
+                                      }
+                                    }
+                                  },
+                                  "range": [
+                                    57,
+                                    65
+                                  ],
+                                  "loc": {
+                                    "start": {
+                                      "line": 2,
+                                      "column": 38
+                                    },
+                                    "end": {
+                                      "line": 2,
+                                      "column": 46
+                                    }
+                                  }
+                                },
+                                "range": [
+                                  54,
+                                  65
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 2,
+                                    "column": 35
+                                  },
+                                  "end": {
+                                    "line": 2,
+                                    "column": 46
+                                  }
+                                }
+                              }
+                            ],
+                            "range": [
+                              52,
+                              67
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 2,
+                                "column": 33
+                              },
+                              "end": {
+                                "line": 2,
+                                "column": 48
+                              }
+                            }
+                          },
+                          "range": [
+                            50,
+                            67
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 31
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 48
+                            }
+                          }
+                        },
+                        "range": [
+                          49,
+                          67
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 30
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 48
+                          }
+                        }
+                      },
+                      "node": {
+                        "type": "TSFunctionType",
+                        "params": [
+                          {
+                            "type": "Identifier",
+                            "name": "p",
+                            "typeAnnotation": {
+                              "type": "TSTypeAnnotation",
+                              "typeAnnotation": {
+                                "type": "TSTypeLiteral",
+                                "members": [
+                                  {
+                                    "type": "TSPropertySignature",
+                                    "computed": false,
+                                    "key": {
+                                      "type": "Identifier",
+                                      "name": "foo",
+                                      "range": [
+                                        54,
+                                        57
+                                      ],
+                                      "loc": {
+                                        "start": {
+                                          "line": 2,
+                                          "column": 35
+                                        },
+                                        "end": {
+                                          "line": 2,
+                                          "column": 38
+                                        }
+                                      }
+                                    },
+                                    "typeAnnotation": {
+                                      "type": "TSTypeAnnotation",
+                                      "typeAnnotation": {
+                                        "type": "TSNumberKeyword",
+                                        "range": [
+                                          59,
+                                          65
+                                        ],
+                                        "loc": {
+                                          "start": {
+                                            "line": 2,
+                                            "column": 40
+                                          },
+                                          "end": {
+                                            "line": 2,
+                                            "column": 46
+                                          }
+                                        }
+                                      },
+                                      "range": [
+                                        57,
+                                        65
+                                      ],
+                                      "loc": {
+                                        "start": {
+                                          "line": 2,
+                                          "column": 38
+                                        },
+                                        "end": {
+                                          "line": 2,
+                                          "column": 46
+                                        }
+                                      }
+                                    },
+                                    "range": [
+                                      54,
+                                      65
+                                    ],
+                                    "loc": {
+                                      "start": {
+                                        "line": 2,
+                                        "column": 35
+                                      },
+                                      "end": {
+                                        "line": 2,
+                                        "column": 46
+                                      }
+                                    }
+                                  }
+                                ],
+                                "range": [
+                                  52,
+                                  67
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 2,
+                                    "column": 33
+                                  },
+                                  "end": {
+                                    "line": 2,
+                                    "column": 48
+                                  }
+                                }
+                              },
+                              "range": [
+                                50,
+                                67
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 2,
+                                  "column": 31
+                                },
+                                "end": {
+                                  "line": 2,
+                                  "column": 48
+                                }
+                              }
+                            },
+                            "range": [
+                              49,
+                              67
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 2,
+                                "column": 30
+                              },
+                              "end": {
+                                "line": 2,
+                                "column": 48
+                              }
+                            }
+                          }
+                        ],
+                        "returnType": {
+                          "type": "TSTypeAnnotation",
+                          "typeAnnotation": {
+                            "type": "TSVoidKeyword",
+                            "range": [
+                              72,
+                              76
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 2,
+                                "column": 53
+                              },
+                              "end": {
+                                "line": 2,
+                                "column": 57
+                              }
+                            }
+                          },
+                          "range": [
+                            69,
+                            76
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 50
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 57
+                            }
+                          }
+                        },
+                        "range": [
+                          48,
+                          76
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 29
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 57
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "references": []
+                }
+              ],
+              "references": [],
+              "childScopes": [],
+              "through": []
+            }
+          ],
+          "through": []
+        },
+        {
+          "type": "function",
+          "variables": [
+            {
+              "name": "arguments",
+              "identifiers": [],
+              "defs": [],
+              "references": []
+            },
+            {
+              "name": "_node",
+              "identifiers": [
+                {
+                  "type": "Identifier",
+                  "name": "_node",
+                  "typeAnnotation": {
+                    "type": "TSTypeAnnotation",
+                    "typeAnnotation": {
+                      "type": "TSTypeReference",
+                      "typeName": {
+                        "type": "Identifier",
+                        "name": "HTMLElement",
+                        "range": [
+                          105,
+                          116
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 27
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 38
+                          }
+                        }
+                      },
+                      "range": [
+                        105,
+                        116
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 27
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 38
+                        }
+                      }
+                    },
+                    "range": [
+                      103,
+                      116
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 25
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 38
+                      }
+                    }
+                  },
+                  "range": [
+                    98,
+                    116
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 20
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 38
+                    }
+                  }
+                }
+              ],
+              "defs": [
+                {
+                  "type": "Parameter",
+                  "name": {
+                    "type": "Identifier",
+                    "name": "_node",
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "typeAnnotation": {
+                        "type": "TSTypeReference",
+                        "typeName": {
+                          "type": "Identifier",
+                          "name": "HTMLElement",
+                          "range": [
+                            105,
+                            116
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 3,
+                              "column": 27
+                            },
+                            "end": {
+                              "line": 3,
+                              "column": 38
+                            }
+                          }
+                        },
+                        "range": [
+                          105,
+                          116
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 27
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 38
+                          }
+                        }
+                      },
+                      "range": [
+                        103,
+                        116
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 25
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 38
+                        }
+                      }
+                    },
+                    "range": [
+                      98,
+                      116
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 20
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 38
+                      }
+                    }
+                  },
+                  "node": {
+                    "type": "FunctionDeclaration",
+                    "async": false,
+                    "body": {
+                      "type": "BlockStatement",
+                      "body": [
+                        {
+                          "type": "VariableDeclaration",
+                          "kind": "const",
+                          "declarations": [
+                            {
+                              "type": "VariableDeclarator",
+                              "id": {
+                                "type": "Identifier",
+                                "name": "result",
+                                "range": [
+                                  153,
+                                  159
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 4,
+                                    "column": 10
+                                  },
+                                  "end": {
+                                    "line": 4,
+                                    "column": 16
+                                  }
+                                }
+                              },
+                              "init": {
+                                "type": "CallExpression",
+                                "arguments": [],
+                                "callee": {
+                                  "type": "Identifier",
+                                  "name": "params",
+                                  "range": [
+                                    162,
+                                    168
+                                  ],
+                                  "loc": {
+                                    "start": {
+                                      "line": 4,
+                                      "column": 19
+                                    },
+                                    "end": {
+                                      "line": 4,
+                                      "column": 25
+                                    }
+                                  }
+                                },
+                                "optional": false,
+                                "range": [
+                                  162,
+                                  170
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 4,
+                                    "column": 19
+                                  },
+                                  "end": {
+                                    "line": 4,
+                                    "column": 27
+                                  }
+                                }
+                              },
+                              "range": [
+                                153,
+                                170
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 4,
+                                  "column": 10
+                                },
+                                "end": {
+                                  "line": 4,
+                                  "column": 27
+                                }
+                              }
+                            }
+                          ],
+                          "range": [
+                            147,
+                            171
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 4,
+                              "column": 4
+                            },
+                            "end": {
+                              "line": 4,
+                              "column": 28
+                            }
+                          }
+                        },
+                        {
+                          "type": "ExpressionStatement",
+                          "expression": {
+                            "type": "CallExpression",
+                            "arguments": [
+                              {
+                                "type": "ObjectExpression",
+                                "properties": [
+                                  {
+                                    "type": "Property",
+                                    "kind": "init",
+                                    "computed": false,
+                                    "key": {
+                                      "type": "Identifier",
+                                      "name": "foo",
+                                      "range": [
+                                        185,
+                                        188
+                                      ],
+                                      "loc": {
+                                        "start": {
+                                          "line": 5,
+                                          "column": 13
+                                        },
+                                        "end": {
+                                          "line": 5,
+                                          "column": 16
+                                        }
+                                      }
+                                    },
+                                    "method": false,
+                                    "shorthand": false,
+                                    "value": {
+                                      "type": "Literal",
+                                      "raw": "1",
+                                      "value": 1,
+                                      "range": [
+                                        190,
+                                        191
+                                      ],
+                                      "loc": {
+                                        "start": {
+                                          "line": 5,
+                                          "column": 18
+                                        },
+                                        "end": {
+                                          "line": 5,
+                                          "column": 19
+                                        }
+                                      }
+                                    },
+                                    "range": [
+                                      185,
+                                      191
+                                    ],
+                                    "loc": {
+                                      "start": {
+                                        "line": 5,
+                                        "column": 13
+                                      },
+                                      "end": {
+                                        "line": 5,
+                                        "column": 19
+                                      }
+                                    }
+                                  }
+                                ],
+                                "range": [
+                                  183,
+                                  193
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 5,
+                                    "column": 11
+                                  },
+                                  "end": {
+                                    "line": 5,
+                                    "column": 21
+                                  }
+                                }
+                              }
+                            ],
+                            "callee": {
+                              "type": "Identifier",
+                              "name": "result",
+                              "range": [
+                                176,
+                                182
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 5,
+                                  "column": 4
+                                },
+                                "end": {
+                                  "line": 5,
+                                  "column": 10
+                                }
+                              }
+                            },
+                            "optional": false,
+                            "range": [
+                              176,
+                              194
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 5,
+                                "column": 4
+                              },
+                              "end": {
+                                "line": 5,
+                                "column": 22
+                              }
+                            }
+                          },
+                          "range": [
+                            176,
+                            195
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 5,
+                              "column": 4
+                            },
+                            "end": {
+                              "line": 5,
+                              "column": 23
+                            }
+                          }
+                        },
+                        {
+                          "type": "ReturnStatement",
+                          "argument": {
+                            "type": "ObjectExpression",
+                            "properties": [
+                              {
+                                "type": "Property",
+                                "kind": "init",
+                                "computed": false,
+                                "key": {
+                                  "type": "Identifier",
+                                  "name": "destroy",
+                                  "range": [
+                                    215,
+                                    222
+                                  ],
+                                  "loc": {
+                                    "start": {
+                                      "line": 7,
+                                      "column": 6
+                                    },
+                                    "end": {
+                                      "line": 7,
+                                      "column": 13
+                                    }
+                                  }
+                                },
+                                "method": false,
+                                "shorthand": false,
+                                "value": {
+                                  "type": "ArrowFunctionExpression",
+                                  "async": false,
+                                  "body": {
+                                    "type": "BlockStatement",
+                                    "body": [],
+                                    "range": [
+                                      230,
+                                      232
+                                    ],
+                                    "loc": {
+                                      "start": {
+                                        "line": 7,
+                                        "column": 21
+                                      },
+                                      "end": {
+                                        "line": 7,
+                                        "column": 23
+                                      }
+                                    }
+                                  },
+                                  "expression": false,
+                                  "generator": false,
+                                  "id": null,
+                                  "params": [],
+                                  "range": [
+                                    224,
+                                    232
+                                  ],
+                                  "loc": {
+                                    "start": {
+                                      "line": 7,
+                                      "column": 15
+                                    },
+                                    "end": {
+                                      "line": 7,
+                                      "column": 23
+                                    }
+                                  }
+                                },
+                                "range": [
+                                  215,
+                                  232
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 7,
+                                    "column": 6
+                                  },
+                                  "end": {
+                                    "line": 7,
+                                    "column": 23
+                                  }
+                                }
+                              }
+                            ],
+                            "range": [
+                              207,
+                              239
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 6,
+                                "column": 11
+                              },
+                              "end": {
+                                "line": 8,
+                                "column": 5
+                              }
+                            }
+                          },
+                          "range": [
+                            200,
+                            240
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 6,
+                              "column": 4
+                            },
+                            "end": {
+                              "line": 8,
+                              "column": 6
+                            }
+                          }
+                        }
+                      ],
+                      "range": [
+                        141,
+                        244
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 63
+                        },
+                        "end": {
+                          "line": 9,
+                          "column": 3
+                        }
+                      }
+                    },
+                    "expression": false,
+                    "generator": false,
+                    "id": {
+                      "type": "Identifier",
+                      "name": "myAction",
+                      "range": [
+                        89,
+                        97
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 11
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 19
+                        }
+                      }
+                    },
+                    "params": [
+                      {
+                        "type": "Identifier",
+                        "name": "_node",
+                        "typeAnnotation": {
+                          "type": "TSTypeAnnotation",
+                          "typeAnnotation": {
+                            "type": "TSTypeReference",
+                            "typeName": {
+                              "type": "Identifier",
+                              "name": "HTMLElement",
+                              "range": [
+                                105,
+                                116
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 3,
+                                  "column": 27
+                                },
+                                "end": {
+                                  "line": 3,
+                                  "column": 38
+                                }
+                              }
+                            },
+                            "range": [
+                              105,
+                              116
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 3,
+                                "column": 27
+                              },
+                              "end": {
+                                "line": 3,
+                                "column": 38
+                              }
+                            }
+                          },
+                          "range": [
+                            103,
+                            116
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 3,
+                              "column": 25
+                            },
+                            "end": {
+                              "line": 3,
+                              "column": 38
+                            }
+                          }
+                        },
+                        "range": [
+                          98,
+                          116
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 20
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 38
+                          }
+                        }
+                      },
+                      {
+                        "type": "Identifier",
+                        "name": "params",
+                        "typeAnnotation": {
+                          "type": "TSTypeAnnotation",
+                          "typeAnnotation": {
+                            "type": "TSTypeReference",
+                            "typeName": {
+                              "type": "Identifier",
+                              "name": "MyActionParam",
+                              "range": [
+                                126,
+                                139
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 3,
+                                  "column": 48
+                                },
+                                "end": {
+                                  "line": 3,
+                                  "column": 61
+                                }
+                              }
+                            },
+                            "range": [
+                              126,
+                              139
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 3,
+                                "column": 48
+                              },
+                              "end": {
+                                "line": 3,
+                                "column": 61
+                              }
+                            }
+                          },
+                          "range": [
+                            124,
+                            139
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 3,
+                              "column": 46
+                            },
+                            "end": {
+                              "line": 3,
+                              "column": 61
+                            }
+                          }
+                        },
+                        "range": [
+                          118,
+                          139
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 40
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 61
+                          }
+                        }
+                      }
+                    ],
+                    "range": [
+                      80,
+                      244
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 9,
+                        "column": 3
+                      }
+                    }
+                  }
+                }
+              ],
+              "references": []
+            },
+            {
+              "name": "params",
+              "identifiers": [
+                {
+                  "type": "Identifier",
+                  "name": "params",
+                  "typeAnnotation": {
+                    "type": "TSTypeAnnotation",
+                    "typeAnnotation": {
+                      "type": "TSTypeReference",
+                      "typeName": {
+                        "type": "Identifier",
+                        "name": "MyActionParam",
+                        "range": [
+                          126,
+                          139
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 48
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 61
+                          }
+                        }
+                      },
+                      "range": [
+                        126,
+                        139
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 48
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 61
+                        }
+                      }
+                    },
+                    "range": [
+                      124,
+                      139
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 46
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 61
+                      }
+                    }
+                  },
+                  "range": [
+                    118,
+                    139
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 40
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 61
+                    }
+                  }
+                }
+              ],
+              "defs": [
+                {
+                  "type": "Parameter",
+                  "name": {
+                    "type": "Identifier",
+                    "name": "params",
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "typeAnnotation": {
+                        "type": "TSTypeReference",
+                        "typeName": {
+                          "type": "Identifier",
+                          "name": "MyActionParam",
+                          "range": [
+                            126,
+                            139
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 3,
+                              "column": 48
+                            },
+                            "end": {
+                              "line": 3,
+                              "column": 61
+                            }
+                          }
+                        },
+                        "range": [
+                          126,
+                          139
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 48
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 61
+                          }
+                        }
+                      },
+                      "range": [
+                        124,
+                        139
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 46
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 61
+                        }
+                      }
+                    },
+                    "range": [
+                      118,
+                      139
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 40
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 61
+                      }
+                    }
+                  },
+                  "node": {
+                    "type": "FunctionDeclaration",
+                    "async": false,
+                    "body": {
+                      "type": "BlockStatement",
+                      "body": [
+                        {
+                          "type": "VariableDeclaration",
+                          "kind": "const",
+                          "declarations": [
+                            {
+                              "type": "VariableDeclarator",
+                              "id": {
+                                "type": "Identifier",
+                                "name": "result",
+                                "range": [
+                                  153,
+                                  159
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 4,
+                                    "column": 10
+                                  },
+                                  "end": {
+                                    "line": 4,
+                                    "column": 16
+                                  }
+                                }
+                              },
+                              "init": {
+                                "type": "CallExpression",
+                                "arguments": [],
+                                "callee": {
+                                  "type": "Identifier",
+                                  "name": "params",
+                                  "range": [
+                                    162,
+                                    168
+                                  ],
+                                  "loc": {
+                                    "start": {
+                                      "line": 4,
+                                      "column": 19
+                                    },
+                                    "end": {
+                                      "line": 4,
+                                      "column": 25
+                                    }
+                                  }
+                                },
+                                "optional": false,
+                                "range": [
+                                  162,
+                                  170
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 4,
+                                    "column": 19
+                                  },
+                                  "end": {
+                                    "line": 4,
+                                    "column": 27
+                                  }
+                                }
+                              },
+                              "range": [
+                                153,
+                                170
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 4,
+                                  "column": 10
+                                },
+                                "end": {
+                                  "line": 4,
+                                  "column": 27
+                                }
+                              }
+                            }
+                          ],
+                          "range": [
+                            147,
+                            171
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 4,
+                              "column": 4
+                            },
+                            "end": {
+                              "line": 4,
+                              "column": 28
+                            }
+                          }
+                        },
+                        {
+                          "type": "ExpressionStatement",
+                          "expression": {
+                            "type": "CallExpression",
+                            "arguments": [
+                              {
+                                "type": "ObjectExpression",
+                                "properties": [
+                                  {
+                                    "type": "Property",
+                                    "kind": "init",
+                                    "computed": false,
+                                    "key": {
+                                      "type": "Identifier",
+                                      "name": "foo",
+                                      "range": [
+                                        185,
+                                        188
+                                      ],
+                                      "loc": {
+                                        "start": {
+                                          "line": 5,
+                                          "column": 13
+                                        },
+                                        "end": {
+                                          "line": 5,
+                                          "column": 16
+                                        }
+                                      }
+                                    },
+                                    "method": false,
+                                    "shorthand": false,
+                                    "value": {
+                                      "type": "Literal",
+                                      "raw": "1",
+                                      "value": 1,
+                                      "range": [
+                                        190,
+                                        191
+                                      ],
+                                      "loc": {
+                                        "start": {
+                                          "line": 5,
+                                          "column": 18
+                                        },
+                                        "end": {
+                                          "line": 5,
+                                          "column": 19
+                                        }
+                                      }
+                                    },
+                                    "range": [
+                                      185,
+                                      191
+                                    ],
+                                    "loc": {
+                                      "start": {
+                                        "line": 5,
+                                        "column": 13
+                                      },
+                                      "end": {
+                                        "line": 5,
+                                        "column": 19
+                                      }
+                                    }
+                                  }
+                                ],
+                                "range": [
+                                  183,
+                                  193
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 5,
+                                    "column": 11
+                                  },
+                                  "end": {
+                                    "line": 5,
+                                    "column": 21
+                                  }
+                                }
+                              }
+                            ],
+                            "callee": {
+                              "type": "Identifier",
+                              "name": "result",
+                              "range": [
+                                176,
+                                182
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 5,
+                                  "column": 4
+                                },
+                                "end": {
+                                  "line": 5,
+                                  "column": 10
+                                }
+                              }
+                            },
+                            "optional": false,
+                            "range": [
+                              176,
+                              194
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 5,
+                                "column": 4
+                              },
+                              "end": {
+                                "line": 5,
+                                "column": 22
+                              }
+                            }
+                          },
+                          "range": [
+                            176,
+                            195
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 5,
+                              "column": 4
+                            },
+                            "end": {
+                              "line": 5,
+                              "column": 23
+                            }
+                          }
+                        },
+                        {
+                          "type": "ReturnStatement",
+                          "argument": {
+                            "type": "ObjectExpression",
+                            "properties": [
+                              {
+                                "type": "Property",
+                                "kind": "init",
+                                "computed": false,
+                                "key": {
+                                  "type": "Identifier",
+                                  "name": "destroy",
+                                  "range": [
+                                    215,
+                                    222
+                                  ],
+                                  "loc": {
+                                    "start": {
+                                      "line": 7,
+                                      "column": 6
+                                    },
+                                    "end": {
+                                      "line": 7,
+                                      "column": 13
+                                    }
+                                  }
+                                },
+                                "method": false,
+                                "shorthand": false,
+                                "value": {
+                                  "type": "ArrowFunctionExpression",
+                                  "async": false,
+                                  "body": {
+                                    "type": "BlockStatement",
+                                    "body": [],
+                                    "range": [
+                                      230,
+                                      232
+                                    ],
+                                    "loc": {
+                                      "start": {
+                                        "line": 7,
+                                        "column": 21
+                                      },
+                                      "end": {
+                                        "line": 7,
+                                        "column": 23
+                                      }
+                                    }
+                                  },
+                                  "expression": false,
+                                  "generator": false,
+                                  "id": null,
+                                  "params": [],
+                                  "range": [
+                                    224,
+                                    232
+                                  ],
+                                  "loc": {
+                                    "start": {
+                                      "line": 7,
+                                      "column": 15
+                                    },
+                                    "end": {
+                                      "line": 7,
+                                      "column": 23
+                                    }
+                                  }
+                                },
+                                "range": [
+                                  215,
+                                  232
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 7,
+                                    "column": 6
+                                  },
+                                  "end": {
+                                    "line": 7,
+                                    "column": 23
+                                  }
+                                }
+                              }
+                            ],
+                            "range": [
+                              207,
+                              239
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 6,
+                                "column": 11
+                              },
+                              "end": {
+                                "line": 8,
+                                "column": 5
+                              }
+                            }
+                          },
+                          "range": [
+                            200,
+                            240
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 6,
+                              "column": 4
+                            },
+                            "end": {
+                              "line": 8,
+                              "column": 6
+                            }
+                          }
+                        }
+                      ],
+                      "range": [
+                        141,
+                        244
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 63
+                        },
+                        "end": {
+                          "line": 9,
+                          "column": 3
+                        }
+                      }
+                    },
+                    "expression": false,
+                    "generator": false,
+                    "id": {
+                      "type": "Identifier",
+                      "name": "myAction",
+                      "range": [
+                        89,
+                        97
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 11
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 19
+                        }
+                      }
+                    },
+                    "params": [
+                      {
+                        "type": "Identifier",
+                        "name": "_node",
+                        "typeAnnotation": {
+                          "type": "TSTypeAnnotation",
+                          "typeAnnotation": {
+                            "type": "TSTypeReference",
+                            "typeName": {
+                              "type": "Identifier",
+                              "name": "HTMLElement",
+                              "range": [
+                                105,
+                                116
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 3,
+                                  "column": 27
+                                },
+                                "end": {
+                                  "line": 3,
+                                  "column": 38
+                                }
+                              }
+                            },
+                            "range": [
+                              105,
+                              116
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 3,
+                                "column": 27
+                              },
+                              "end": {
+                                "line": 3,
+                                "column": 38
+                              }
+                            }
+                          },
+                          "range": [
+                            103,
+                            116
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 3,
+                              "column": 25
+                            },
+                            "end": {
+                              "line": 3,
+                              "column": 38
+                            }
+                          }
+                        },
+                        "range": [
+                          98,
+                          116
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 20
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 38
+                          }
+                        }
+                      },
+                      {
+                        "type": "Identifier",
+                        "name": "params",
+                        "typeAnnotation": {
+                          "type": "TSTypeAnnotation",
+                          "typeAnnotation": {
+                            "type": "TSTypeReference",
+                            "typeName": {
+                              "type": "Identifier",
+                              "name": "MyActionParam",
+                              "range": [
+                                126,
+                                139
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 3,
+                                  "column": 48
+                                },
+                                "end": {
+                                  "line": 3,
+                                  "column": 61
+                                }
+                              }
+                            },
+                            "range": [
+                              126,
+                              139
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 3,
+                                "column": 48
+                              },
+                              "end": {
+                                "line": 3,
+                                "column": 61
+                              }
+                            }
+                          },
+                          "range": [
+                            124,
+                            139
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 3,
+                              "column": 46
+                            },
+                            "end": {
+                              "line": 3,
+                              "column": 61
+                            }
+                          }
+                        },
+                        "range": [
+                          118,
+                          139
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 40
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 61
+                          }
+                        }
+                      }
+                    ],
+                    "range": [
+                      80,
+                      244
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 9,
+                        "column": 3
+                      }
+                    }
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "identifier": {
+                    "type": "Identifier",
+                    "name": "params",
+                    "range": [
+                      162,
+                      168
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 19
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 25
+                      }
+                    }
+                  },
+                  "from": "function",
+                  "init": null,
+                  "resolved": {
+                    "type": "Identifier",
+                    "name": "params",
+                    "typeAnnotation": {
+                      "type": "TSTypeAnnotation",
+                      "typeAnnotation": {
+                        "type": "TSTypeReference",
+                        "typeName": {
+                          "type": "Identifier",
+                          "name": "MyActionParam",
+                          "range": [
+                            126,
+                            139
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 3,
+                              "column": 48
+                            },
+                            "end": {
+                              "line": 3,
+                              "column": 61
+                            }
+                          }
+                        },
+                        "range": [
+                          126,
+                          139
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 48
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 61
+                          }
+                        }
+                      },
+                      "range": [
+                        124,
+                        139
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 46
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 61
+                        }
+                      }
+                    },
+                    "range": [
+                      118,
+                      139
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 40
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 61
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "name": "result",
+              "identifiers": [
+                {
+                  "type": "Identifier",
+                  "name": "result",
+                  "range": [
+                    153,
+                    159
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 10
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 16
+                    }
+                  }
+                }
+              ],
+              "defs": [
+                {
+                  "type": "Variable",
+                  "name": {
+                    "type": "Identifier",
+                    "name": "result",
+                    "range": [
+                      153,
+                      159
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 10
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 16
+                      }
+                    }
+                  },
+                  "node": {
+                    "type": "VariableDeclarator",
+                    "id": {
+                      "type": "Identifier",
+                      "name": "result",
+                      "range": [
+                        153,
+                        159
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 10
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 16
+                        }
+                      }
+                    },
+                    "init": {
+                      "type": "CallExpression",
+                      "arguments": [],
+                      "callee": {
+                        "type": "Identifier",
+                        "name": "params",
+                        "range": [
+                          162,
+                          168
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 4,
+                            "column": 19
+                          },
+                          "end": {
+                            "line": 4,
+                            "column": 25
+                          }
+                        }
+                      },
+                      "optional": false,
+                      "range": [
+                        162,
+                        170
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 19
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 27
+                        }
+                      }
+                    },
+                    "range": [
+                      153,
+                      170
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 10
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 27
+                      }
+                    }
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "identifier": {
+                    "type": "Identifier",
+                    "name": "result",
+                    "range": [
+                      153,
+                      159
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 10
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 16
+                      }
+                    }
+                  },
+                  "from": "function",
+                  "init": true,
+                  "resolved": {
+                    "type": "Identifier",
+                    "name": "result",
+                    "range": [
+                      153,
+                      159
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 10
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 16
+                      }
+                    }
+                  }
+                },
+                {
+                  "identifier": {
+                    "type": "Identifier",
+                    "name": "result",
+                    "range": [
+                      176,
+                      182
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 4
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 10
+                      }
+                    }
+                  },
+                  "from": "function",
+                  "init": null,
+                  "resolved": {
+                    "type": "Identifier",
+                    "name": "result",
+                    "range": [
+                      153,
+                      159
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 10
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 16
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "references": [
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "HTMLElement",
+                "range": [
+                  105,
+                  116
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 27
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 38
+                  }
+                }
+              },
+              "from": "function",
+              "init": null,
+              "resolved": null
+            },
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "MyActionParam",
+                "range": [
+                  126,
+                  139
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 48
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 61
+                  }
+                }
+              },
+              "from": "function",
+              "init": null,
+              "resolved": {
+                "type": "Identifier",
+                "name": "MyActionParam",
+                "range": [
+                  26,
+                  39
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 20
+                  }
+                }
+              }
+            },
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "result",
+                "range": [
+                  153,
+                  159
+                ],
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 16
+                  }
+                }
+              },
+              "from": "function",
+              "init": true,
+              "resolved": {
+                "type": "Identifier",
+                "name": "result",
+                "range": [
+                  153,
+                  159
+                ],
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 16
+                  }
+                }
+              }
+            },
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "params",
+                "range": [
+                  162,
+                  168
+                ],
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 19
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 25
+                  }
+                }
+              },
+              "from": "function",
+              "init": null,
+              "resolved": {
+                "type": "Identifier",
+                "name": "params",
+                "typeAnnotation": {
+                  "type": "TSTypeAnnotation",
+                  "typeAnnotation": {
+                    "type": "TSTypeReference",
+                    "typeName": {
+                      "type": "Identifier",
+                      "name": "MyActionParam",
+                      "range": [
+                        126,
+                        139
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 48
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 61
+                        }
+                      }
+                    },
+                    "range": [
+                      126,
+                      139
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 48
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 61
+                      }
+                    }
+                  },
+                  "range": [
+                    124,
+                    139
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 46
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 61
+                    }
+                  }
+                },
+                "range": [
+                  118,
+                  139
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 40
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 61
+                  }
+                }
+              }
+            },
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "result",
+                "range": [
+                  176,
+                  182
+                ],
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 10
+                  }
+                }
+              },
+              "from": "function",
+              "init": null,
+              "resolved": {
+                "type": "Identifier",
+                "name": "result",
+                "range": [
+                  153,
+                  159
+                ],
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 16
+                  }
+                }
+              }
+            }
+          ],
+          "childScopes": [
+            {
+              "type": "function",
+              "variables": [],
+              "references": [],
+              "childScopes": [],
+              "through": []
+            }
+          ],
+          "through": [
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "HTMLElement",
+                "range": [
+                  105,
+                  116
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 27
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 38
+                  }
+                }
+              },
+              "from": "function",
+              "init": null,
+              "resolved": null
+            },
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "MyActionParam",
+                "range": [
+                  126,
+                  139
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 48
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 61
+                  }
+                }
+              },
+              "from": "function",
+              "init": null,
+              "resolved": {
+                "type": "Identifier",
+                "name": "MyActionParam",
+                "range": [
+                  26,
+                  39
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 20
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "variables": [],
+          "references": [],
+          "childScopes": [
+            {
+              "type": "function",
+              "variables": [
+                {
+                  "name": "param",
+                  "identifiers": [
+                    {
+                      "type": "Identifier",
+                      "name": "param",
+                      "range": [
+                        297,
+                        302
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 14,
+                          "column": 12
+                        },
+                        "end": {
+                          "line": 14,
+                          "column": 17
+                        }
+                      }
+                    }
+                  ],
+                  "defs": [
+                    {
+                      "type": "Parameter",
+                      "name": {
+                        "type": "Identifier",
+                        "name": "param",
+                        "range": [
+                          297,
+                          302
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 14,
+                            "column": 12
+                          },
+                          "end": {
+                            "line": 14,
+                            "column": 17
+                          }
+                        }
+                      },
+                      "node": {
+                        "type": "ArrowFunctionExpression",
+                        "async": false,
+                        "body": {
+                          "type": "BlockStatement",
+                          "body": [
+                            {
+                              "type": "ExpressionStatement",
+                              "expression": {
+                                "type": "MemberExpression",
+                                "computed": false,
+                                "object": {
+                                  "type": "Identifier",
+                                  "name": "param",
+                                  "range": [
+                                    315,
+                                    320
+                                  ],
+                                  "loc": {
+                                    "start": {
+                                      "line": 15,
+                                      "column": 6
+                                    },
+                                    "end": {
+                                      "line": 15,
+                                      "column": 11
+                                    }
+                                  }
+                                },
+                                "optional": false,
+                                "property": {
+                                  "type": "Identifier",
+                                  "name": "foo",
+                                  "range": [
+                                    321,
+                                    324
+                                  ],
+                                  "loc": {
+                                    "start": {
+                                      "line": 15,
+                                      "column": 12
+                                    },
+                                    "end": {
+                                      "line": 15,
+                                      "column": 15
+                                    }
+                                  }
+                                },
+                                "range": [
+                                  315,
+                                  324
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 15,
+                                    "column": 6
+                                  },
+                                  "end": {
+                                    "line": 15,
+                                    "column": 15
+                                  }
+                                }
+                              },
+                              "range": [
+                                315,
+                                325
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 15,
+                                  "column": 6
+                                },
+                                "end": {
+                                  "line": 15,
+                                  "column": 16
+                                }
+                              }
+                            }
+                          ],
+                          "range": [
+                            307,
+                            331
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 14,
+                              "column": 22
+                            },
+                            "end": {
+                              "line": 16,
+                              "column": 5
+                            }
+                          }
+                        },
+                        "expression": false,
+                        "generator": false,
+                        "id": null,
+                        "params": [
+                          {
+                            "type": "Identifier",
+                            "name": "param",
+                            "range": [
+                              297,
+                              302
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 14,
+                                "column": 12
+                              },
+                              "end": {
+                                "line": 14,
+                                "column": 17
+                              }
+                            }
+                          }
+                        ],
+                        "range": [
+                          296,
+                          331
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 14,
+                            "column": 11
+                          },
+                          "end": {
+                            "line": 16,
+                            "column": 5
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "references": [
+                    {
+                      "identifier": {
+                        "type": "Identifier",
+                        "name": "param",
+                        "range": [
+                          315,
+                          320
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 15,
+                            "column": 6
+                          },
+                          "end": {
+                            "line": 15,
+                            "column": 11
+                          }
+                        }
+                      },
+                      "from": "function",
+                      "init": null,
+                      "resolved": {
+                        "type": "Identifier",
+                        "name": "param",
+                        "range": [
+                          297,
+                          302
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 14,
+                            "column": 12
+                          },
+                          "end": {
+                            "line": 14,
+                            "column": 17
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "references": [
+                {
+                  "identifier": {
+                    "type": "Identifier",
+                    "name": "param",
+                    "range": [
+                      315,
+                      320
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 15,
+                        "column": 6
+                      },
+                      "end": {
+                        "line": 15,
+                        "column": 11
+                      }
+                    }
+                  },
+                  "from": "function",
+                  "init": null,
+                  "resolved": {
+                    "type": "Identifier",
+                    "name": "param",
+                    "range": [
+                      297,
+                      302
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 14,
+                        "column": 12
+                      },
+                      "end": {
+                        "line": 14,
+                        "column": 17
+                      }
+                    }
+                  }
+                }
+              ],
+              "childScopes": [],
+              "through": []
+            }
+          ],
+          "through": []
+        }
+      ],
+      "through": [
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "HTMLElement",
+            "range": [
+              105,
+              116
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 27
+              },
+              "end": {
+                "line": 3,
+                "column": 38
+              }
+            }
+          },
+          "from": "function",
+          "init": null,
+          "resolved": null
+        },
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "Parameters",
+            "range": [
+              341,
+              351
+            ],
+            "loc": {
+              "start": {
+                "line": 19,
+                "column": 0
+              },
+              "end": {
+                "line": 19,
+                "column": 10
+              }
+            }
+          },
+          "from": "module",
+          "init": null,
+          "resolved": null
+        }
+      ]
+    }
+  ],
+  "through": []
+}

--- a/tests/fixtures/parser/ast/ts-use01-type-output.svelte
+++ b/tests/fixtures/parser/ast/ts-use01-type-output.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  type MyActionParam = () => (p: { foo: number }) => void; // MyActionParam: MyActionParam, p: { foo: number; }
+  function myAction(_node: HTMLElement, params: MyActionParam) { // myAction: { (_node: HTMLElement, params: MyActionParam): { destroy: () => void; }; (_node: HTMLElement, params: MyActionParam): { ...; }; }, _node: HTMLElement, params: MyActionParam
+    const result = params(); // result: (p: { foo: number; }) => void, params(): (p: { foo: number; }) => void
+    result({ foo: 1 }); // result({ foo: 1 }): void
+    return {
+      destroy: () => {}, // destroy: () => void
+    };
+  }
+</script>
+
+<div
+  use:myAction={() => { // myAction: { (_node: HTMLElement, params: MyActionParam): { destroy: () => void; }; (_node: HTMLElement, params: MyActionParam): { ...; }; }
+    return (param) => { // param: { foo: number; }
+      param.foo; // param.foo: number
+    };
+  }}
+/>


### PR DESCRIPTION
This PR improves assigning the correct type to `use:` directive parameters.

Related to https://github.com/sveltejs/eslint-plugin-svelte/issues/442