### PR TITLE
Only parsing styles on-demand

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -189,7 +189,7 @@ export function parseForESLint(
   const styleElement = ast.body.find(
     (b): b is SvelteStyleElement => b.type === "SvelteStyleElement"
   );
-  const styleContext = parseStyleContext(styleElement, ctx);
+  let styleContext: StyleContext | null = null;
 
   resultScript.ast = ast as any;
   resultScript.services = Object.assign(resultScript.services || {}, {
@@ -198,6 +198,9 @@ export function parseForESLint(
       return resultTemplate.svelteAst.html;
     },
     getStyleContext() {
+      if (styleContext === null) {
+        styleContext = parseStyleContext(styleElement, ctx);
+      }
       return styleContext;
     },
     styleNodeLoc,


### PR DESCRIPTION
Following up on #340, this function optimizes style parsing to only happen when requested.

Before:
```
$ time pnpm run test
pnpm run test  40,59s user 1,94s system 184% cpu 22,998 total
```

After:
```
$ pnpm run test
pnpm run test  39,06s user 1,93s system 183% cpu 22,395 total
```

The improvement is only modest on the test suite (but I imageine there aren't that many styles in the test suite), but seeing how simple of an optimization it is, seems worth it to me...