### PR TITLE
chore: update PostCSS and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint-scope": "^7.0.0",
     "eslint-visitor-keys": "^3.0.0",
     "espree": "^9.0.0",
-    "postcss": "^8.4.23",
+    "postcss": "^8.4.25",
     "postcss-scss": "^4.0.6"
   },
   "devDependencies": {

--- a/tests/fixtures/parser/style-context/empty-style-element-output.json
+++ b/tests/fixtures/parser/style-context/empty-style-element-output.json
@@ -10,9 +10,9 @@
     "source": {
       "inputId": 0,
       "start": {
-        "offset": 52,
+        "column": 8,
         "line": 7,
-        "column": 8
+        "offset": 52
       }
     },
     "lastEach": 1,

--- a/tests/fixtures/parser/style-context/one-line-css-output.json
+++ b/tests/fixtures/parser/style-context/one-line-css-output.json
@@ -24,16 +24,16 @@
             },
             "type": "decl",
             "source": {
+              "end": {
+                "column": 30,
+                "line": 7,
+                "offset": 99
+              },
               "inputId": 0,
               "start": {
-                "offset": 89,
+                "column": 20,
                 "line": 7,
-                "column": 20
-              },
-              "end": {
-                "offset": 99,
-                "line": 7,
-                "column": 30
+                "offset": 89
               }
             },
             "prop": "color",
@@ -41,16 +41,16 @@
           }
         ],
         "source": {
+          "end": {
+            "column": 32,
+            "line": 7,
+            "offset": 101
+          },
           "inputId": 0,
           "start": {
-            "offset": 78,
+            "column": 9,
             "line": 7,
-            "column": 9
-          },
-          "end": {
-            "offset": 101,
-            "line": 7,
-            "column": 32
+            "offset": 78
           }
         },
         "selector": ".myClass",
@@ -61,9 +61,9 @@
     "source": {
       "inputId": 0,
       "start": {
-        "offset": 77,
+        "column": 8,
         "line": 7,
-        "column": 8
+        "offset": 77
       }
     },
     "lastEach": 1,

--- a/tests/fixtures/parser/style-context/parse-error-output.json
+++ b/tests/fixtures/parser/style-context/parse-error-output.json
@@ -10,10 +10,10 @@
     "endLine": 4,
     "endColumn": 24,
     "input": {
-      "line": 4,
       "column": 11,
-      "endLine": 4,
       "endColumn": 24,
+      "endLine": 4,
+      "line": 4,
       "source": "\n  // This syntax is intentionally invalid CSS - this is to be used to test resiliency against invalid input\n  .container {\n    class .div-class/35\n      # Weird comment\n      color: red;\n\n    .span-class begin\n      font-weight: bold;\n    end\n  }\n"
     }
   }

--- a/tests/fixtures/parser/style-context/simple-css-output.json
+++ b/tests/fixtures/parser/style-context/simple-css-output.json
@@ -24,16 +24,16 @@
             },
             "type": "decl",
             "source": {
+              "end": {
+                "column": 15,
+                "line": 11,
+                "offset": 117
+              },
               "inputId": 0,
               "start": {
-                "offset": 107,
+                "column": 5,
                 "line": 11,
-                "column": 5
-              },
-              "end": {
-                "offset": 117,
-                "line": 11,
-                "column": 15
+                "offset": 107
               }
             },
             "prop": "color",
@@ -41,16 +41,16 @@
           }
         ],
         "source": {
+          "end": {
+            "column": 3,
+            "line": 12,
+            "offset": 121
+          },
           "inputId": 0,
           "start": {
-            "offset": 92,
+            "column": 3,
             "line": 10,
-            "column": 3
-          },
-          "end": {
-            "offset": 121,
-            "line": 12,
-            "column": 3
+            "offset": 92
           }
         },
         "selector": ".myClass",
@@ -73,16 +73,16 @@
             },
             "type": "decl",
             "source": {
+              "end": {
+                "column": 24,
+                "line": 15,
+                "offset": 153
+              },
               "inputId": 0,
               "start": {
-                "offset": 134,
+                "column": 5,
                 "line": 15,
-                "column": 5
-              },
-              "end": {
-                "offset": 153,
-                "line": 15,
-                "column": 24
+                "offset": 134
               }
             },
             "prop": "font-size",
@@ -90,16 +90,16 @@
           }
         ],
         "source": {
+          "end": {
+            "column": 3,
+            "line": 16,
+            "offset": 157
+          },
           "inputId": 0,
           "start": {
-            "offset": 126,
+            "column": 3,
             "line": 14,
-            "column": 3
-          },
-          "end": {
-            "offset": 157,
-            "line": 16,
-            "column": 3
+            "offset": 126
           }
         },
         "selector": "b",
@@ -110,9 +110,9 @@
     "source": {
       "inputId": 0,
       "start": {
-        "offset": 89,
+        "column": 8,
         "line": 9,
-        "column": 8
+        "offset": 89
       }
     },
     "lastEach": 1,

--- a/tests/fixtures/parser/style-context/simple-scss-output.json
+++ b/tests/fixtures/parser/style-context/simple-scss-output.json
@@ -36,16 +36,16 @@
                 },
                 "type": "comment",
                 "source": {
-                  "inputId": 0,
-                  "start": {
-                    "offset": 169,
-                    "line": 10,
-                    "column": 7
-                  },
                   "end": {
                     "offset": 196,
                     "line": 10,
                     "column": 34
+                  },
+                  "inputId": 0,
+                  "start": {
+                    "column": 7,
+                    "line": 10,
+                    "offset": 169
                   }
                 },
                 "text": "This is an inline comment"
@@ -57,16 +57,16 @@
                 },
                 "type": "decl",
                 "source": {
+                  "end": {
+                    "column": 17,
+                    "line": 11,
+                    "offset": 214
+                  },
                   "inputId": 0,
                   "start": {
-                    "offset": 204,
+                    "column": 7,
                     "line": 11,
-                    "column": 7
-                  },
-                  "end": {
-                    "offset": 214,
-                    "line": 11,
-                    "column": 17
+                    "offset": 204
                   }
                 },
                 "prop": "color",
@@ -74,16 +74,16 @@
               }
             ],
             "source": {
+              "end": {
+                "column": 5,
+                "line": 12,
+                "offset": 220
+              },
               "inputId": 0,
               "start": {
-                "offset": 150,
+                "column": 5,
                 "line": 9,
-                "column": 5
-              },
-              "end": {
-                "offset": 220,
-                "line": 12,
-                "column": 5
+                "offset": 150
               }
             },
             "selector": ".div-class",
@@ -106,16 +106,16 @@
                 },
                 "type": "decl",
                 "source": {
+                  "end": {
+                    "column": 24,
+                    "line": 15,
+                    "offset": 264
+                  },
                   "inputId": 0,
                   "start": {
-                    "offset": 247,
+                    "column": 7,
                     "line": 15,
-                    "column": 7
-                  },
-                  "end": {
-                    "offset": 264,
-                    "line": 15,
-                    "column": 24
+                    "offset": 247
                   }
                 },
                 "prop": "font-weight",
@@ -123,16 +123,16 @@
               }
             ],
             "source": {
+              "end": {
+                "column": 5,
+                "line": 16,
+                "offset": 270
+              },
               "inputId": 0,
               "start": {
-                "offset": 227,
+                "column": 5,
                 "line": 14,
-                "column": 5
-              },
-              "end": {
-                "offset": 270,
-                "line": 16,
-                "column": 5
+                "offset": 227
               }
             },
             "selector": ".span-class",
@@ -141,16 +141,16 @@
           }
         ],
         "source": {
+          "end": {
+            "column": 3,
+            "line": 17,
+            "offset": 274
+          },
           "inputId": 0,
           "start": {
-            "offset": 133,
+            "column": 3,
             "line": 8,
-            "column": 3
-          },
-          "end": {
-            "offset": 274,
-            "line": 17,
-            "column": 3
+            "offset": 133
           }
         },
         "selector": ".container",
@@ -161,9 +161,9 @@
     "source": {
       "inputId": 0,
       "start": {
-        "offset": 130,
+        "column": 20,
         "line": 7,
-        "column": 20
+        "offset": 130
       }
     },
     "lastEach": 1,

--- a/tests/fixtures/parser/style-context/unrelated-style-attr-output.json
+++ b/tests/fixtures/parser/style-context/unrelated-style-attr-output.json
@@ -24,16 +24,16 @@
             },
             "type": "decl",
             "source": {
+              "end": {
+                "column": 15,
+                "line": 11,
+                "offset": 134
+              },
               "inputId": 0,
               "start": {
-                "offset": 124,
+                "column": 5,
                 "line": 11,
-                "column": 5
-              },
-              "end": {
-                "offset": 134,
-                "line": 11,
-                "column": 15
+                "offset": 124
               }
             },
             "prop": "color",
@@ -41,16 +41,16 @@
           }
         ],
         "source": {
+          "end": {
+            "column": 3,
+            "line": 12,
+            "offset": 138
+          },
           "inputId": 0,
           "start": {
-            "offset": 109,
+            "column": 3,
             "line": 10,
-            "column": 3
-          },
-          "end": {
-            "offset": 138,
-            "line": 12,
-            "column": 3
+            "offset": 109
           }
         },
         "selector": ".myClass",
@@ -73,16 +73,16 @@
             },
             "type": "decl",
             "source": {
+              "end": {
+                "column": 24,
+                "line": 15,
+                "offset": 170
+              },
               "inputId": 0,
               "start": {
-                "offset": 151,
+                "column": 5,
                 "line": 15,
-                "column": 5
-              },
-              "end": {
-                "offset": 170,
-                "line": 15,
-                "column": 24
+                "offset": 151
               }
             },
             "prop": "font-size",
@@ -90,16 +90,16 @@
           }
         ],
         "source": {
+          "end": {
+            "column": 3,
+            "line": 16,
+            "offset": 174
+          },
           "inputId": 0,
           "start": {
-            "offset": 143,
+            "column": 3,
             "line": 14,
-            "column": 3
-          },
-          "end": {
-            "offset": 174,
-            "line": 16,
-            "column": 3
+            "offset": 143
           }
         },
         "selector": "b",
@@ -110,9 +110,9 @@
     "source": {
       "inputId": 0,
       "start": {
-        "offset": 106,
+        "column": 25,
         "line": 9,
-        "column": 25
+        "offset": 106
       }
     },
     "lastEach": 1,


### PR DESCRIPTION
I created this PR because `eco-system-ci` is failed.
https://github.com/sveltejs/svelte-ecosystem-ci/actions/runs/5483027087/jobs/9994935125

After investigation, I found that this was due to a change in the order of JSON properties when postcss 8.4.25 was released.
I think we can not say that this was not a bug, so I simply upgraded the postcss version and fixed tests.