### PR TITLE
feat: change it to use modern AST, if svelte v5 is installed

### DIFF
--- a/.changeset/loud-geese-trade.md
+++ b/.changeset/loud-geese-trade.md
@@ -1,0 +1,5 @@
+---
+"svelte-eslint-parser": minor
+---
+
+feat: change it to use modern AST, if svelte v5 is installed

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -15,7 +15,6 @@ import type * as SvAST from "../parser/svelte-ast-types";
 import type * as Compiler from "svelte/compiler";
 import { ScriptLetContext } from "./script-let";
 import { LetDirectiveCollections } from "./let-directive-collection";
-import type { AttributeToken } from "../parser/html";
 import { parseAttributes } from "../parser/html";
 import { sortedLastIndex } from "../utils";
 import {
@@ -204,8 +203,16 @@ export class Context {
         if (block.selfClosing) {
           continue;
         }
-        const lang = block.attrs.find((attr) => attr.key.name === "lang");
-        if (!lang || !lang.value || lang.value.value === "html") {
+        const lang = block.attrs.find((attr) => attr.name === "lang");
+        if (!lang || !Array.isArray(lang.value)) {
+          continue;
+        }
+        const langValue = lang.value[0];
+        if (
+          !langValue ||
+          langValue.type !== "Text" ||
+          langValue.data === "html"
+        ) {
           continue;
         }
       }
@@ -235,7 +242,13 @@ export class Context {
             spaces.slice(start, block.contentRange[0]) +
             code.slice(...block.contentRange);
           for (const attr of block.attrs) {
-            scriptAttrs[attr.key.name] = attr.value?.value;
+            if (Array.isArray(attr.value)) {
+              const attrValue = attr.value[0];
+              scriptAttrs[attr.name] =
+                attrValue && attrValue.type === "Text"
+                  ? attrValue.data
+                  : undefined;
+            }
           }
         } else {
           scriptCode += spaces.slice(start, block.contentRange[1]);
@@ -361,7 +374,7 @@ type Block =
   | {
       tag: "script" | "style" | "template";
       originalTag: string;
-      attrs: AttributeToken[];
+      attrs: Compiler.Attribute[];
       selfClosing?: false;
       contentRange: [number, number];
       startTagRange: [number, number];
@@ -372,7 +385,7 @@ type Block =
 type SelfClosingBlock = {
   tag: "script" | "style" | "template";
   originalTag: string;
-  attrs: AttributeToken[];
+  attrs: Compiler.Attribute[];
   selfClosing: true;
   startTagRange: [number, number];
 };
@@ -394,7 +407,7 @@ function* extractBlocks(code: string): IterableIterator<Block> {
 
     const lowerTag = tag.toLowerCase() as "script" | "style" | "template";
 
-    let attrs: AttributeToken[] = [];
+    let attrs: Compiler.Attribute[] = [];
     if (!nextChar.trim()) {
       const attrsData = parseAttributes(code, startTagOpenRe.lastIndex);
       attrs = attrsData.attributes;

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -12,6 +12,7 @@ import type {
 } from "../ast";
 import type ESTree from "estree";
 import type * as SvAST from "../parser/svelte-ast-types";
+import type * as Compiler from "svelte/compiler";
 import { ScriptLetContext } from "./script-let";
 import { LetDirectiveCollections } from "./let-directive-collection";
 import type { AttributeToken } from "../parser/html";
@@ -164,6 +165,19 @@ export class Context {
     | SvAST.SlotTemplate
     | SvAST.Slot
     | SvAST.Title
+    | Compiler.RegularElement
+    | Compiler.Component
+    | Compiler.SvelteComponent
+    | Compiler.SvelteElement
+    | Compiler.SvelteWindow
+    | Compiler.SvelteBody
+    | Compiler.SvelteHead
+    | Compiler.SvelteDocument
+    | Compiler.SvelteFragment
+    | Compiler.SvelteSelf
+    | Compiler.SvelteOptionsRaw
+    | Compiler.SlotElement
+    | Compiler.TitleElement
   >();
 
   public readonly snippets: SvelteSnippetBlock[] = [];

--- a/src/context/script-let.ts
+++ b/src/context/script-let.ts
@@ -246,11 +246,11 @@ export class ScriptLetContext {
   }
 
   public addVariableDeclarator(
-    expression: ESTree.AssignmentExpression,
+    declarator: ESTree.VariableDeclarator | ESTree.AssignmentExpression,
     parent: SvelteNode,
     ...callbacks: ScriptLetCallback<ESTree.VariableDeclarator>[]
   ): ScriptLetCallback<ESTree.VariableDeclarator>[] {
-    const range = getNodeRange(expression);
+    const range = getNodeRange(declarator);
     const part = this.ctx.code.slice(...range);
     this.appendScript(
       `const ${part};`,

--- a/src/context/script-let.ts
+++ b/src/context/script-let.ts
@@ -250,7 +250,11 @@ export class ScriptLetContext {
     parent: SvelteNode,
     ...callbacks: ScriptLetCallback<ESTree.VariableDeclarator>[]
   ): ScriptLetCallback<ESTree.VariableDeclarator>[] {
-    const range = getNodeRange(declarator);
+    const range =
+      declarator.type === "VariableDeclarator"
+        ? // As of Svelte v5-next.65, VariableDeclarator nodes do not have location information.
+          [getNodeRange(declarator.id)[0], getNodeRange(declarator.init!)[1]]
+        : getNodeRange(declarator);
     const part = this.ctx.code.slice(...range);
     this.appendScript(
       `const ${part};`,

--- a/src/parser/compat.ts
+++ b/src/parser/compat.ts
@@ -12,24 +12,24 @@ export type Child =
 type HasChildren = { children?: SvAST.TemplateNode[] };
 // Root
 export function getFragmentFromRoot(
-  svelteAst: SvAST.Ast | SvAST.AstLegacy,
+  svelteAst: Compiler.Root | SvAST.AstLegacy,
 ): SvAST.Fragment | Compiler.Fragment | undefined {
   return (
-    (svelteAst as SvAST.Ast).fragment ?? (svelteAst as SvAST.AstLegacy).html
+    (svelteAst as Compiler.Root).fragment ?? (svelteAst as SvAST.AstLegacy).html
   );
 }
 export function getInstanceFromRoot(
-  svelteAst: SvAST.Ast | SvAST.AstLegacy,
-): SvAST.Script | Compiler.Script | undefined {
-  return (svelteAst as SvAST.AstLegacy).instance;
+  svelteAst: Compiler.Root | SvAST.AstLegacy,
+): SvAST.Script | Compiler.Script | null | undefined {
+  return svelteAst.instance;
 }
 export function getModuleFromRoot(
-  svelteAst: SvAST.Ast | SvAST.AstLegacy,
-): SvAST.Script | Compiler.Script | undefined {
-  return (svelteAst as SvAST.AstLegacy).module;
+  svelteAst: Compiler.Root | SvAST.AstLegacy,
+): SvAST.Script | Compiler.Script | null | undefined {
+  return svelteAst.module;
 }
 export function getOptionsFromRoot(
-  svelteAst: SvAST.Ast | SvAST.AstLegacy,
+  svelteAst: Compiler.Root | SvAST.AstLegacy,
 ): Compiler.SvelteOptionsRaw | null {
   return (svelteAst as any).options?.__raw__ ?? null;
 }

--- a/src/parser/compat.ts
+++ b/src/parser/compat.ts
@@ -1,0 +1,228 @@
+/** Compatibility for Svelte v4 <-> v5 */
+import type ESTree from "estree";
+import type * as SvAST from "./svelte-ast-types";
+import type * as Compiler from "svelte/compiler";
+
+export type Child =
+  | Compiler.Text
+  | Compiler.Tag
+  | Compiler.ElementLike
+  | Compiler.Block
+  | Compiler.Comment;
+type HasChildren = { children?: SvAST.TemplateNode[] };
+// Root
+export function getFragmentFromRoot(
+  svelteAst: SvAST.Ast | SvAST.AstLegacy,
+): SvAST.Fragment | Compiler.Fragment | undefined {
+  return (
+    (svelteAst as SvAST.Ast).fragment ?? (svelteAst as SvAST.AstLegacy).html
+  );
+}
+export function getInstanceFromRoot(
+  svelteAst: SvAST.Ast | SvAST.AstLegacy,
+): SvAST.Script | Compiler.Script | undefined {
+  return (svelteAst as SvAST.AstLegacy).instance;
+}
+export function getModuleFromRoot(
+  svelteAst: SvAST.Ast | SvAST.AstLegacy,
+): SvAST.Script | Compiler.Script | undefined {
+  return (svelteAst as SvAST.AstLegacy).module;
+}
+export function getOptionsFromRoot(
+  svelteAst: SvAST.Ast | SvAST.AstLegacy,
+): Compiler.SvelteOptionsRaw | null {
+  return (svelteAst as any).options?.__raw__ ?? null;
+}
+
+export function getChildren(
+  fragment: Required<HasChildren> | { nodes: (Child | SvAST.TemplateNode)[] },
+): (SvAST.TemplateNode | Child)[];
+export function getChildren(
+  fragment: HasChildren | { nodes: (Child | SvAST.TemplateNode)[] },
+): (SvAST.TemplateNode | Child)[] | undefined;
+export function getChildren(
+  fragment: HasChildren | { nodes: (Child | SvAST.TemplateNode)[] },
+): (SvAST.TemplateNode | Child)[] | undefined {
+  return (
+    (fragment as { nodes: (Child | SvAST.TemplateNode)[] }).nodes ??
+    (fragment as HasChildren).children
+  );
+}
+export function trimChildren(
+  children: (SvAST.TemplateNode | Child)[],
+): (SvAST.TemplateNode | Child)[] {
+  if (
+    !startsWithWhitespace(children[0]) &&
+    !endsWithWhitespace(children[children.length - 1])
+  ) {
+    return children;
+  }
+
+  const nodes = [...children];
+  while (isWhitespace(nodes[0])) {
+    nodes.shift();
+  }
+  const first = nodes[0];
+  if (startsWithWhitespace(first)) {
+    nodes[0] = { ...first, data: first.data.trimStart() };
+  }
+  while (isWhitespace(nodes[nodes.length - 1])) {
+    nodes.pop();
+  }
+  const last = nodes[nodes.length - 1];
+  if (endsWithWhitespace(last)) {
+    nodes[nodes.length - 1] = { ...last, data: last.data.trimEnd() };
+  }
+  return nodes;
+
+  function startsWithWhitespace(
+    child: SvAST.TemplateNode | Child | undefined,
+  ): child is SvAST.Text | Compiler.Text {
+    if (!child) {
+      return false;
+    }
+    return child.type === "Text" && child.data.trimStart() !== child.data;
+  }
+
+  function endsWithWhitespace(
+    child: SvAST.TemplateNode | Child | undefined,
+  ): child is SvAST.Text | Compiler.Text {
+    if (!child) {
+      return false;
+    }
+    return child.type === "Text" && child.data.trimEnd() !== child.data;
+  }
+
+  function isWhitespace(child: SvAST.TemplateNode | Child | undefined) {
+    if (!child) {
+      return false;
+    }
+    return child.type === "Text" && child.data.trim() === "";
+  }
+}
+export function getFragment(
+  element:
+    | {
+        fragment: Compiler.Fragment;
+      }
+    | Required<HasChildren>,
+): Compiler.Fragment | Required<HasChildren>;
+export function getFragment(
+  element:
+    | {
+        fragment: Compiler.Fragment;
+      }
+    | HasChildren,
+): Compiler.Fragment | HasChildren;
+export function getFragment(
+  element:
+    | {
+        fragment: Compiler.Fragment;
+      }
+    | HasChildren,
+): Compiler.Fragment | HasChildren {
+  if (
+    (
+      element as {
+        fragment: Compiler.Fragment;
+      }
+    ).fragment
+  ) {
+    return (
+      element as {
+        fragment: Compiler.Fragment;
+      }
+    ).fragment;
+  }
+  return element as HasChildren;
+}
+export function getModifiers(
+  node: SvAST.Directive | SvAST.StyleDirective | Compiler.Directive,
+): string[] {
+  return (node as { modifiers?: string[] }).modifiers ?? [];
+}
+// IfBlock
+export function getTestFromIfBlock(
+  block: SvAST.IfBlock | Compiler.IfBlock,
+): ESTree.Expression {
+  return (
+    (block as SvAST.IfBlock).expression ?? (block as Compiler.IfBlock).test
+  );
+}
+export function getConsequentFromIfBlock(
+  block: SvAST.IfBlock | Compiler.IfBlock,
+): Compiler.Fragment | SvAST.IfBlock {
+  return (block as Compiler.IfBlock).consequent ?? (block as SvAST.IfBlock);
+}
+export function getAlternateFromIfBlock(
+  block: SvAST.IfBlock | Compiler.IfBlock,
+): Compiler.Fragment | SvAST.ElseBlock | null {
+  if ((block as Compiler.IfBlock).alternate) {
+    return (block as Compiler.IfBlock).alternate;
+  }
+  return (block as SvAST.IfBlock).else ?? null;
+}
+// EachBlock
+export function getBodyFromEachBlock(
+  block: SvAST.EachBlock | Compiler.EachBlock,
+): Compiler.Fragment | SvAST.EachBlock {
+  if ((block as Compiler.EachBlock).body) {
+    return (block as Compiler.EachBlock).body;
+  }
+  return block as SvAST.EachBlock;
+}
+export function getFallbackFromEachBlock(
+  block: SvAST.EachBlock | Compiler.EachBlock,
+): Compiler.Fragment | SvAST.ElseBlock | null {
+  if ((block as Compiler.EachBlock).fallback) {
+    return (block as Compiler.EachBlock).fallback!;
+  }
+  return (block as SvAST.EachBlock).else ?? null;
+}
+// SnippetBlock
+export function getBodyFromSnippetBlock(
+  block: SvAST.SnippetBlock | Compiler.SnippetBlock,
+): Compiler.Fragment | SvAST.SnippetBlock {
+  if ((block as Compiler.SnippetBlock).body) {
+    return (block as Compiler.SnippetBlock).body;
+  }
+  return block as SvAST.SnippetBlock;
+}
+// AwaitBlock
+export function getPendingFromAwaitBlock(
+  block: SvAST.AwaitBlock | Compiler.AwaitBlock,
+): Compiler.Fragment | SvAST.PendingBlock | null {
+  const pending = block.pending;
+  if (!pending) {
+    return null;
+  }
+  if (pending.type === "Fragment") {
+    return pending;
+  }
+  return pending.skip ? null : pending;
+}
+export function getThenFromAwaitBlock(
+  block: SvAST.AwaitBlock | Compiler.AwaitBlock,
+): Compiler.Fragment | SvAST.ThenBlock | null {
+  const then = block.then;
+  if (!then) {
+    return null;
+  }
+  if (then.type === "Fragment") {
+    return then;
+  }
+  return then.skip ? null : then;
+}
+
+export function getCatchFromAwaitBlock(
+  block: SvAST.AwaitBlock | Compiler.AwaitBlock,
+): Compiler.Fragment | SvAST.CatchBlock | null {
+  const catchFragment = block.catch;
+  if (!catchFragment) {
+    return null;
+  }
+  if (catchFragment.type === "Fragment") {
+    return catchFragment;
+  }
+  return catchFragment.skip ? null : catchFragment;
+}

--- a/src/parser/compat.ts
+++ b/src/parser/compat.ts
@@ -179,15 +179,6 @@ export function getFallbackFromEachBlock(
   }
   return (block as SvAST.EachBlock).else ?? null;
 }
-// SnippetBlock
-export function getBodyFromSnippetBlock(
-  block: SvAST.SnippetBlock | Compiler.SnippetBlock,
-): Compiler.Fragment | SvAST.SnippetBlock {
-  if ((block as Compiler.SnippetBlock).body) {
-    return (block as Compiler.SnippetBlock).body;
-  }
-  return block as SvAST.SnippetBlock;
-}
 // AwaitBlock
 export function getPendingFromAwaitBlock(
   block: SvAST.AwaitBlock | Compiler.AwaitBlock,

--- a/src/parser/compat.ts
+++ b/src/parser/compat.ts
@@ -204,7 +204,6 @@ export function getThenFromAwaitBlock(
   }
   return then.skip ? null : then;
 }
-
 export function getCatchFromAwaitBlock(
   block: SvAST.AwaitBlock | Compiler.AwaitBlock,
 ): Compiler.Fragment | SvAST.CatchBlock | null {
@@ -216,4 +215,16 @@ export function getCatchFromAwaitBlock(
     return catchFragment;
   }
   return catchFragment.skip ? null : catchFragment;
+}
+
+// ConstTag
+export function getDeclaratorFromConstTag(
+  node: SvAST.ConstTag | Compiler.ConstTag,
+):
+  | ESTree.AssignmentExpression
+  | Compiler.ConstTag["declaration"]["declarations"][0] {
+  return (
+    (node as Compiler.ConstTag).declaration?.declarations?.[0] ??
+    (node as SvAST.ConstTag).expression
+  );
 }

--- a/src/parser/converts/attr.ts
+++ b/src/parser/converts/attr.ts
@@ -27,13 +27,9 @@ import type * as SvAST from "../svelte-ast-types";
 import type * as Compiler from "svelte/compiler";
 import { getWithLoc, indexOf } from "./common";
 import { convertMustacheTag } from "./mustache";
-import {
-  convertAttributeValueTokenToLiteral,
-  convertTextToLiteral,
-} from "./text";
+import { convertTextToLiteral } from "./text";
 import { ParseError } from "../../errors";
 import type { ScriptLetCallback } from "../../context/script-let";
-import type { AttributeToken } from "../html";
 import { svelteVersion } from "../svelte-version";
 import { hasTypeInfo } from "../../utils";
 import { getModifiers } from "../compat";
@@ -122,42 +118,6 @@ export function* convertAttributes(
       attr.start,
       ctx,
     );
-  }
-}
-
-/** Convert for attribute tokens */
-export function* convertAttributeTokens(
-  attributes: AttributeToken[],
-  parent: SvelteStartTag,
-  ctx: Context,
-): IterableIterator<SvelteAttribute> {
-  for (const attr of attributes) {
-    const attribute: SvelteAttribute = {
-      type: "SvelteAttribute",
-      boolean: false,
-      key: null as any,
-      value: [],
-      parent,
-      ...ctx.getConvertLocation({
-        start: attr.key.start,
-        end: attr.value?.end ?? attr.key.end,
-      }),
-    };
-    attribute.key = {
-      type: "SvelteName",
-      name: attr.key.name,
-      parent: attribute,
-      ...ctx.getConvertLocation(attr.key),
-    };
-    ctx.addToken("HTMLIdentifier", attr.key);
-    if (attr.value == null) {
-      attribute.boolean = true;
-    } else {
-      attribute.value.push(
-        convertAttributeValueTokenToLiteral(attr.value, attribute, ctx),
-      );
-    }
-    yield attribute;
   }
 }
 

--- a/src/parser/converts/attr.ts
+++ b/src/parser/converts/attr.ts
@@ -60,35 +60,19 @@ export function* convertAttributes(
       yield convertAttribute(attr, parent, ctx);
       continue;
     }
-    if (attr.type === "SpreadAttribute") {
+    if (attr.type === "SpreadAttribute" || attr.type === "Spread") {
       yield convertSpreadAttribute(attr, parent, ctx);
       continue;
     }
-    if (attr.type === "Spread") {
-      yield convertSpreadAttribute(attr, parent, ctx);
-      continue;
-    }
-    if (attr.type === "BindDirective") {
+    if (attr.type === "BindDirective" || attr.type === "Binding") {
       yield convertBindingDirective(attr, parent, ctx);
       continue;
     }
-    if (attr.type === "Binding") {
-      yield convertBindingDirective(attr, parent, ctx);
-      continue;
-    }
-    if (attr.type === "OnDirective") {
+    if (attr.type === "OnDirective" || attr.type === "EventHandler") {
       yield convertEventHandlerDirective(attr, parent, ctx);
       continue;
     }
-    if (attr.type === "EventHandler") {
-      yield convertEventHandlerDirective(attr, parent, ctx);
-      continue;
-    }
-    if (attr.type === "ClassDirective") {
-      yield convertClassDirective(attr, parent, ctx);
-      continue;
-    }
-    if (attr.type === "Class") {
+    if (attr.type === "ClassDirective" || attr.type === "Class") {
       yield convertClassDirective(attr, parent, ctx);
       continue;
     }
@@ -96,35 +80,19 @@ export function* convertAttributes(
       yield convertStyleDirective(attr, parent, ctx);
       continue;
     }
-    if (attr.type === "TransitionDirective") {
+    if (attr.type === "TransitionDirective" || attr.type === "Transition") {
       yield convertTransitionDirective(attr, parent, ctx);
       continue;
     }
-    if (attr.type === "Transition") {
-      yield convertTransitionDirective(attr, parent, ctx);
-      continue;
-    }
-    if (attr.type === "AnimateDirective") {
+    if (attr.type === "AnimateDirective" || attr.type === "Animation") {
       yield convertAnimationDirective(attr, parent, ctx);
       continue;
     }
-    if (attr.type === "Animation") {
-      yield convertAnimationDirective(attr, parent, ctx);
-      continue;
-    }
-    if (attr.type === "UseDirective") {
+    if (attr.type === "UseDirective" || attr.type === "Action") {
       yield convertActionDirective(attr, parent, ctx);
       continue;
     }
-    if (attr.type === "Action") {
-      yield convertActionDirective(attr, parent, ctx);
-      continue;
-    }
-    if (attr.type === "LetDirective") {
-      yield convertLetDirective(attr, parent, ctx);
-      continue;
-    }
-    if (attr.type === "Let") {
+    if (attr.type === "LetDirective" || attr.type === "Let") {
       yield convertLetDirective(attr, parent, ctx);
       continue;
     }

--- a/src/parser/converts/attr.ts
+++ b/src/parser/converts/attr.ts
@@ -190,6 +190,9 @@ function convertAttribute(
     });
     return sAttr;
   }
+  // Not required for shorthands. Therefore, register the token here.
+  ctx.addToken("HTMLIdentifier", keyRange);
+
   processAttributeValue(
     node.value as (
       | SvAST.Text
@@ -201,9 +204,6 @@ function convertAttribute(
     parent,
     ctx,
   );
-
-  // Not required for shorthands. Therefore, register the token here.
-  ctx.addToken("HTMLIdentifier", keyRange);
 
   return attribute;
 }

--- a/src/parser/converts/block.ts
+++ b/src/parser/converts/block.ts
@@ -437,7 +437,12 @@ export function convertAwaitBlock(
       ...ctx.getConvertLocation({
         start: thenStart,
         end: endIndexFromFragment(then, () => {
-          return awaitBlock.pending?.range[1] ?? node.end;
+          return (
+            ctx.code.indexOf(
+              "}",
+              node.value ? getWithLoc(node.value).end : thenStart + 5,
+            ) + 1
+          );
         }),
       }),
     };
@@ -518,13 +523,13 @@ export function convertAwaitBlock(
       (awaitBlock as SvelteAwaitBlockAwaitCatch).kind = "await-catch";
     }
     const catchStart =
-      awaitBlock.pending || awaitBlock.then
+      awaitBlock.then || awaitBlock.pending
         ? startBlockIndex(
             ctx.code,
             node.error
               ? getWithLoc(node.error).start
               : startIndexFromFragment(catchFragment, () => {
-                  return (awaitBlock.pending || awaitBlock.then).range[1];
+                  return (awaitBlock.then || awaitBlock.pending).range[1];
                 }),
             ":catch",
           )
@@ -538,7 +543,12 @@ export function convertAwaitBlock(
       ...ctx.getConvertLocation({
         start: catchStart,
         end: endIndexFromFragment(catchFragment, () => {
-          return (awaitBlock.pending || awaitBlock.then)?.range[1] ?? node.end;
+          return (
+            ctx.code.indexOf(
+              "}",
+              node.error ? getWithLoc(node.error).end : catchStart + 6,
+            ) + 1
+          );
         }),
       }),
     } as SvelteAwaitCatchBlock;

--- a/src/parser/converts/block.ts
+++ b/src/parser/converts/block.ts
@@ -1,4 +1,5 @@
 import type * as SvAST from "../svelte-ast-types";
+import type * as Compiler from "svelte/compiler";
 import type {
   SvelteAwaitBlock,
   SvelteAwaitBlockAwaitCatch,
@@ -20,6 +21,20 @@ import type { Context } from "../../context";
 import { convertChildren } from "./element";
 import { getWithLoc, indexOf, lastIndexOf } from "./common";
 import type * as ESTree from "estree";
+import {
+  getAlternateFromIfBlock,
+  getBodyFromEachBlock,
+  getBodyFromSnippetBlock,
+  getCatchFromAwaitBlock,
+  getChildren,
+  getConsequentFromIfBlock,
+  getFallbackFromEachBlock,
+  getFragment,
+  getPendingFromAwaitBlock,
+  getTestFromIfBlock,
+  getThenFromAwaitBlock,
+  trimChildren,
+} from "../compat";
 
 /** Get start index of block */
 function startBlockIndex(
@@ -46,20 +61,65 @@ function startBlockIndex(
   );
 }
 
+function startIndexFromFragment(
+  fragment:
+    | Compiler.Fragment
+    | SvAST.ElseBlock
+    | SvAST.ThenBlock
+    | SvAST.CatchBlock,
+  getBeforeEndIndex: () => number,
+) {
+  if ((fragment as { start: number }).start != null) {
+    return (fragment as { start: number }).start;
+  }
+  const children = getChildren(fragment);
+  return children.length ? children[0].start : getBeforeEndIndex();
+}
+
+function endIndexFromFragment(
+  fragment:
+    | Compiler.Fragment
+    | SvAST.IfBlock
+    | SvAST.ElseBlock
+    | SvAST.PendingBlock
+    | SvAST.EachBlock
+    | SvAST.ThenBlock
+    | SvAST.CatchBlock,
+  getBeforeEndIndex: () => number,
+): number {
+  if ((fragment as { end: number }).end != null) {
+    return (fragment as { end: number }).end;
+  }
+  const children = getChildren(fragment);
+  return children.length
+    ? children[children.length - 1].end
+    : getBeforeEndIndex();
+}
+
+function endIndexFromBlock(
+  fragment: Compiler.Fragment | SvAST.PendingBlock,
+  lastExpression: ESTree.Node | { start: number; end: number },
+  ctx: Context,
+) {
+  return endIndexFromFragment(fragment, () => {
+    return ctx.code.indexOf("}", getWithLoc(lastExpression).end) + 1;
+  });
+}
+
 export function convertIfBlock(
-  node: SvAST.IfBlock,
+  node: SvAST.IfBlock | Compiler.IfBlock,
   parent: SvelteIfBlock["parent"],
   ctx: Context,
 ): SvelteIfBlockAlone;
 export function convertIfBlock(
-  node: SvAST.IfBlock,
+  node: SvAST.IfBlock | Compiler.IfBlock,
   parent: SvelteIfBlock["parent"],
   ctx: Context,
   elseif: true,
 ): SvelteIfBlockElseIf;
 /** Convert for IfBlock */
 export function convertIfBlock(
-  node: SvAST.IfBlock,
+  node: SvAST.IfBlock | Compiler.IfBlock,
   parent: SvelteIfBlock["parent"],
   ctx: Context,
   elseif?: true,
@@ -81,10 +141,24 @@ export function convertIfBlock(
     ...ctx.getConvertLocation({ start: nodeStart, end: node.end }),
   } as SvelteIfBlock;
 
-  ctx.scriptLet.nestIfBlock(node.expression, ifBlock, (es) => {
+  const test = getTestFromIfBlock(node);
+  ctx.scriptLet.nestIfBlock(test, ifBlock, (es) => {
     ifBlock.expression = es;
   });
-  ifBlock.children.push(...convertChildren(node, ifBlock, ctx));
+  const consequent = getConsequentFromIfBlock(node);
+
+  ifBlock.children.push(
+    ...convertChildren(
+      {
+        nodes:
+          // Adjust for Svelte v5
+          trimChildren(getChildren(consequent)),
+      },
+      ifBlock,
+      ctx,
+    ),
+  );
+
   ctx.scriptLet.closeScope();
   if (elseif) {
     const index = ctx.code.indexOf("if", nodeStart);
@@ -92,22 +166,16 @@ export function convertIfBlock(
   }
   extractMustacheBlockTokens(ifBlock, ctx, { startOnly: elseif });
 
-  if (!node.else) {
+  const elseFragment = getAlternateFromIfBlock(node);
+  if (!elseFragment) {
     return ifBlock;
   }
 
-  let baseStart = node.else.start;
-  if (node.else.children.length === 1) {
-    const c = node.else.children[0];
-    if (c.type === "IfBlock" && c.elseif) {
-      baseStart = Math.min(baseStart, c.start, getWithLoc(c.expression).start);
-    }
-  }
+  const elseStart = startBlockIndexForElse(elseFragment, consequent, test, ctx);
 
-  const elseStart = startBlockIndex(ctx.code, baseStart - 1, ":else");
-
-  if (node.else.children.length === 1) {
-    const c = node.else.children[0];
+  const elseChildren = getChildren(elseFragment);
+  if (elseChildren.length === 1) {
+    const c = elseChildren[0];
     if (c.type === "IfBlock" && c.elseif) {
       const elseBlock: SvelteElseBlockElseIf = {
         type: "SvelteElseBlock",
@@ -116,7 +184,7 @@ export function convertIfBlock(
         parent: ifBlock,
         ...ctx.getConvertLocation({
           start: elseStart,
-          end: node.else.end,
+          end: c.end,
         }),
       };
       ifBlock.else = elseBlock;
@@ -139,22 +207,59 @@ export function convertIfBlock(
     parent: ifBlock,
     ...ctx.getConvertLocation({
       start: elseStart,
-      end: node.else.end,
+      end: endIndexFromFragment(
+        elseFragment,
+        () => ctx.code.indexOf("}", elseStart + 5) + 1,
+      ),
     }),
   };
   ifBlock.else = elseBlock;
 
   ctx.scriptLet.nestBlock(elseBlock);
-  elseBlock.children.push(...convertChildren(node.else, elseBlock, ctx));
+  elseBlock.children.push(
+    ...convertChildren(
+      {
+        nodes:
+          // Adjust for Svelte v5
+          trimChildren(elseChildren),
+      },
+      elseBlock,
+      ctx,
+    ),
+  );
   ctx.scriptLet.closeScope();
   extractMustacheBlockTokens(elseBlock, ctx, { startOnly: true });
 
   return ifBlock;
 }
 
+function startBlockIndexForElse(
+  elseFragment: Compiler.Fragment | SvAST.ElseBlock,
+  beforeFragment: Compiler.Fragment | SvAST.IfBlock | SvAST.EachBlock,
+  lastExpression: ESTree.Node | { start: number; end: number },
+  ctx: Context,
+) {
+  let baseStart: number;
+  const elseChildren = getChildren(elseFragment);
+  if (elseChildren.length > 0) {
+    const c = elseChildren[0];
+    baseStart = c.start;
+    if (c.type === "IfBlock" && c.elseif) {
+      baseStart = Math.min(baseStart, getWithLoc(getTestFromIfBlock(c)).start);
+    }
+  } else {
+    const beforeEnd = endIndexFromFragment(beforeFragment, () => {
+      return ctx.code.indexOf("}", getWithLoc(lastExpression).end) + 1;
+    });
+    baseStart = beforeEnd + 1;
+  }
+
+  return startBlockIndex(ctx.code, baseStart - 1, ":else");
+}
+
 /** Convert for EachBlock */
 export function convertEachBlock(
-  node: SvAST.EachBlock,
+  node: SvAST.EachBlock | Compiler.EachBlock,
   parent: SvelteEachBlock["parent"],
   ctx: Context,
 ): SvelteEachBlock {
@@ -205,16 +310,33 @@ export function convertEachBlock(
       eachBlock.key = key;
     });
   }
-  eachBlock.children.push(...convertChildren(node, eachBlock, ctx));
+  const body = getBodyFromEachBlock(node);
+  eachBlock.children.push(
+    ...convertChildren(
+      {
+        nodes:
+          // Adjust for Svelte v5
+          trimChildren(getChildren(body)),
+      },
+      eachBlock,
+      ctx,
+    ),
+  );
 
   ctx.scriptLet.closeScope();
   extractMustacheBlockTokens(eachBlock, ctx);
 
-  if (!node.else) {
+  const fallbackFragment = getFallbackFromEachBlock(node);
+  if (!fallbackFragment) {
     return eachBlock;
   }
 
-  const elseStart = startBlockIndex(ctx.code, node.else.start - 1, ":else");
+  const elseStart = startBlockIndexForElse(
+    fallbackFragment,
+    body,
+    node.key || indexRange || node.context,
+    ctx,
+  );
 
   const elseBlock: SvelteElseBlockAlone = {
     type: "SvelteElseBlock",
@@ -223,13 +345,23 @@ export function convertEachBlock(
     parent: eachBlock,
     ...ctx.getConvertLocation({
       start: elseStart,
-      end: node.else.end,
+      end: endIndexFromFragment(fallbackFragment, () => elseStart),
     }),
   };
   eachBlock.else = elseBlock;
 
   ctx.scriptLet.nestBlock(elseBlock);
-  elseBlock.children.push(...convertChildren(node.else, elseBlock, ctx));
+  elseBlock.children.push(
+    ...convertChildren(
+      {
+        nodes:
+          // Adjust for Svelte v5
+          trimChildren(getChildren(fallbackFragment)),
+      },
+      elseBlock,
+      ctx,
+    ),
+  );
   ctx.scriptLet.closeScope();
   extractMustacheBlockTokens(elseBlock, ctx, { startOnly: true });
 
@@ -238,7 +370,7 @@ export function convertEachBlock(
 
 /** Convert for AwaitBlock */
 export function convertAwaitBlock(
-  node: SvAST.AwaitBlock,
+  node: SvAST.AwaitBlock | Compiler.AwaitBlock,
   parent: SvelteAwaitBlock["parent"],
   ctx: Context,
 ): SvelteAwaitBlock {
@@ -263,30 +395,40 @@ export function convertAwaitBlock(
     },
   );
 
-  if (!node.pending.skip) {
+  const pending = getPendingFromAwaitBlock(node);
+  if (pending) {
     const pendingBlock: SvelteAwaitPendingBlock = {
       type: "SvelteAwaitPendingBlock",
       children: [],
       parent: awaitBlock,
       ...ctx.getConvertLocation({
         start: awaitBlock.range[0],
-        end: node.pending.end,
+        end: endIndexFromBlock(pending, node.expression, ctx),
       }),
     };
     ctx.scriptLet.nestBlock(pendingBlock);
-    pendingBlock.children.push(
-      ...convertChildren(node.pending, pendingBlock, ctx),
-    );
+    pendingBlock.children.push(...convertChildren(pending, pendingBlock, ctx));
     awaitBlock.pending = pendingBlock;
     ctx.scriptLet.closeScope();
   }
-  if (!node.then.skip) {
-    const awaitThen = Boolean(node.pending.skip);
+  const then = getThenFromAwaitBlock(node);
+  if (then) {
+    const awaitThen = !pending;
     if (awaitThen) {
       (awaitBlock as SvelteAwaitBlockAwaitThen).kind = "await-then";
     }
 
-    const thenStart = awaitBlock.pending ? node.then.start : nodeStart;
+    const thenStart = awaitBlock.pending
+      ? startBlockIndex(
+          ctx.code,
+          node.value
+            ? getWithLoc(node.value).start
+            : startIndexFromFragment(then, () => {
+                return awaitBlock.pending.range[1];
+              }),
+          ":then",
+        )
+      : nodeStart;
     const thenBlock: SvelteAwaitThenBlock = {
       type: "SvelteAwaitThenBlock",
       awaitThen,
@@ -295,7 +437,9 @@ export function convertAwaitBlock(
       parent: awaitBlock as any,
       ...ctx.getConvertLocation({
         start: thenStart,
-        end: node.then.end,
+        end: endIndexFromFragment(then, () => {
+          return awaitBlock.pending?.range[1] ?? node.end;
+        }),
       }),
     };
     if (node.value) {
@@ -352,7 +496,7 @@ export function convertAwaitBlock(
     } else {
       ctx.scriptLet.nestBlock(thenBlock);
     }
-    thenBlock.children.push(...convertChildren(node.then, thenBlock, ctx));
+    thenBlock.children.push(...convertChildren(then, thenBlock, ctx));
     if (awaitBlock.pending) {
       extractMustacheBlockTokens(thenBlock, ctx, { startOnly: true });
     } else {
@@ -368,13 +512,24 @@ export function convertAwaitBlock(
     awaitBlock.then = thenBlock;
     ctx.scriptLet.closeScope();
   }
-  if (!node.catch.skip) {
-    const awaitCatch = Boolean(node.pending.skip && node.then.skip);
+  const catchFragment = getCatchFromAwaitBlock(node);
+  if (catchFragment) {
+    const awaitCatch = !pending && !then;
     if (awaitCatch) {
       (awaitBlock as SvelteAwaitBlockAwaitCatch).kind = "await-catch";
     }
     const catchStart =
-      awaitBlock.pending || awaitBlock.then ? node.catch.start : nodeStart;
+      awaitBlock.pending || awaitBlock.then
+        ? startBlockIndex(
+            ctx.code,
+            node.error
+              ? getWithLoc(node.error).start
+              : startIndexFromFragment(catchFragment, () => {
+                  return (awaitBlock.pending || awaitBlock.then).range[1];
+                }),
+            ":catch",
+          )
+        : nodeStart;
     const catchBlock = {
       type: "SvelteAwaitCatchBlock",
       awaitCatch,
@@ -383,7 +538,9 @@ export function convertAwaitBlock(
       parent: awaitBlock,
       ...ctx.getConvertLocation({
         start: catchStart,
-        end: node.catch.end,
+        end: endIndexFromFragment(catchFragment, () => {
+          return (awaitBlock.pending || awaitBlock.then)?.range[1] ?? node.end;
+        }),
       }),
     } as SvelteAwaitCatchBlock;
 
@@ -401,7 +558,9 @@ export function convertAwaitBlock(
     } else {
       ctx.scriptLet.nestBlock(catchBlock);
     }
-    catchBlock.children.push(...convertChildren(node.catch, catchBlock, ctx));
+    catchBlock.children.push(
+      ...convertChildren(catchFragment, catchBlock, ctx),
+    );
     if (awaitBlock.pending || awaitBlock.then) {
       extractMustacheBlockTokens(catchBlock, ctx, { startOnly: true });
     } else {
@@ -425,7 +584,7 @@ export function convertAwaitBlock(
 
 /** Convert for KeyBlock */
 export function convertKeyBlock(
-  node: SvAST.KeyBlock,
+  node: SvAST.KeyBlock | Compiler.KeyBlock,
   parent: SvelteKeyBlock["parent"],
   ctx: Context,
 ): SvelteKeyBlock {
@@ -443,7 +602,17 @@ export function convertKeyBlock(
   });
 
   ctx.scriptLet.nestBlock(keyBlock);
-  keyBlock.children.push(...convertChildren(node, keyBlock, ctx));
+  keyBlock.children.push(
+    ...convertChildren(
+      {
+        nodes:
+          // Adjust for Svelte v5
+          trimChildren(getChildren(getFragment(node))),
+      },
+      keyBlock,
+      ctx,
+    ),
+  );
   ctx.scriptLet.closeScope();
 
   extractMustacheBlockTokens(keyBlock, ctx);
@@ -453,7 +622,7 @@ export function convertKeyBlock(
 
 /** Convert for SnippetBlock */
 export function convertSnippetBlock(
-  node: SvAST.SnippetBlock,
+  node: SvAST.SnippetBlock | Compiler.SnippetBlock,
   parent: SvelteSnippetBlock["parent"],
   ctx: Context,
 ): SvelteSnippetBlock {
@@ -487,7 +656,18 @@ export function convertSnippetBlock(
     },
   );
 
-  snippetBlock.children.push(...convertChildren(node, snippetBlock, ctx));
+  const body = getBodyFromSnippetBlock(node);
+  snippetBlock.children.push(
+    ...convertChildren(
+      {
+        nodes:
+          // Adjust for Svelte v5
+          trimChildren(getChildren(body)),
+      },
+      snippetBlock,
+      ctx,
+    ),
+  );
 
   ctx.scriptLet.closeScope();
   extractMustacheBlockTokens(snippetBlock, ctx);

--- a/src/parser/converts/block.ts
+++ b/src/parser/converts/block.ts
@@ -24,7 +24,6 @@ import type * as ESTree from "estree";
 import {
   getAlternateFromIfBlock,
   getBodyFromEachBlock,
-  getBodyFromSnippetBlock,
   getCatchFromAwaitBlock,
   getChildren,
   getConsequentFromIfBlock,
@@ -622,7 +621,7 @@ export function convertKeyBlock(
 
 /** Convert for SnippetBlock */
 export function convertSnippetBlock(
-  node: SvAST.SnippetBlock | Compiler.SnippetBlock,
+  node: Compiler.SnippetBlock,
   parent: SvelteSnippetBlock["parent"],
   ctx: Context,
 ): SvelteSnippetBlock {
@@ -656,13 +655,12 @@ export function convertSnippetBlock(
     },
   );
 
-  const body = getBodyFromSnippetBlock(node);
   snippetBlock.children.push(
     ...convertChildren(
       {
         nodes:
           // Adjust for Svelte v5
-          trimChildren(getChildren(body)),
+          trimChildren(node.body.nodes),
       },
       snippetBlock,
       ctx,

--- a/src/parser/converts/const.ts
+++ b/src/parser/converts/const.ts
@@ -1,10 +1,12 @@
 import type { SvelteConstTag } from "../../ast";
 import type { Context } from "../../context";
+import { getDeclaratorFromConstTag } from "../compat";
 import type * as SvAST from "../svelte-ast-types";
+import type * as Compiler from "svelte/compiler";
 
 /** Convert for ConstTag */
 export function convertConstTag(
-  node: SvAST.ConstTag,
+  node: SvAST.ConstTag | Compiler.ConstTag,
   parent: SvelteConstTag["parent"],
   ctx: Context,
 ): SvelteConstTag {
@@ -15,7 +17,7 @@ export function convertConstTag(
     ...ctx.getConvertLocation(node),
   };
   ctx.scriptLet.addVariableDeclarator(
-    node.expression,
+    getDeclaratorFromConstTag(node),
     mustache,
     (declaration) => {
       mustache.declaration = declaration;

--- a/src/parser/converts/element.ts
+++ b/src/parser/converts/element.ts
@@ -239,7 +239,7 @@ function extractLetDirectives(fragment: {
     SvAST.LetDirective | Compiler.LetDirective
   >[] = [];
   for (const attr of fragment.attributes) {
-    if (attr.type === "Let" || attr.type === "LetDirective") {
+    if (attr.type === "LetDirective" || attr.type === "Let") {
       letDirectives.push(attr);
     } else {
       attributes.push(attr);

--- a/src/parser/converts/mustache.ts
+++ b/src/parser/converts/mustache.ts
@@ -7,10 +7,11 @@ import type {
 import type { Context } from "../../context";
 import type * as SvAST from "../svelte-ast-types";
 import { hasTypeInfo } from "../../utils";
+import type * as Compiler from "svelte/compiler";
 
 /** Convert for MustacheTag */
 export function convertMustacheTag(
-  node: SvAST.MustacheTag,
+  node: SvAST.MustacheTag | Compiler.ExpressionTag,
   parent: SvelteMustacheTag["parent"],
   typing: string | null,
   ctx: Context,
@@ -19,7 +20,7 @@ export function convertMustacheTag(
 }
 /** Convert for MustacheTag */
 export function convertRawMustacheTag(
-  node: SvAST.RawMustacheTag,
+  node: SvAST.RawMustacheTag | Compiler.HtmlTag,
   parent: SvelteMustacheTag["parent"],
   ctx: Context,
 ): SvelteMustacheTagRaw {
@@ -65,7 +66,11 @@ export function convertDebugTag(
 
 /** Convert to MustacheTag */
 function convertMustacheTag0<T extends SvelteMustacheTag>(
-  node: SvAST.MustacheTag | SvAST.RawMustacheTag,
+  node:
+    | SvAST.MustacheTag
+    | SvAST.RawMustacheTag
+    | Compiler.ExpressionTag
+    | Compiler.HtmlTag,
   kind: T["kind"],
   parent: T["parent"],
   typing: string | null,

--- a/src/parser/converts/render.ts
+++ b/src/parser/converts/render.ts
@@ -1,12 +1,12 @@
 import type * as ESTree from "estree";
 import type { SvelteRenderTag } from "../../ast";
 import type { Context } from "../../context";
-import type * as SvAST from "../svelte-ast-types";
 import { getWithLoc } from "./common";
+import type * as Compiler from "svelte/compiler";
 
 /** Convert for RenderTag */
 export function convertRenderTag(
-  node: SvAST.RenderTag,
+  node: Compiler.RenderTag,
   parent: SvelteRenderTag["parent"],
   ctx: Context,
 ): SvelteRenderTag {

--- a/src/parser/converts/root.ts
+++ b/src/parser/converts/root.ts
@@ -1,4 +1,5 @@
 import type * as SvAST from "../svelte-ast-types";
+import * as Compiler from "svelte/compiler";
 import type {
   SvelteAttribute,
   SvelteGenericsDirective,
@@ -30,7 +31,7 @@ import {
  * Convert root
  */
 export function convertSvelteRoot(
-  svelteAst: SvAST.Ast | SvAST.AstLegacy,
+  svelteAst: Compiler.Root | SvAST.AstLegacy,
   ctx: Context,
 ): SvelteProgram {
   const ast: SvelteProgram = {

--- a/src/parser/converts/root.ts
+++ b/src/parser/converts/root.ts
@@ -12,7 +12,7 @@ import type {
 import {} from "./common";
 import type { Context } from "../../context";
 import { convertChildren, extractElementTags } from "./element";
-import { convertAttributeTokens } from "./attr";
+import { convertAttributes } from "./attr";
 import type { Scope } from "eslint-scope";
 import { parseScriptWithoutAnalyzeScope } from "../script";
 import type { TSESParseForESLintResult } from "../typescript/types";
@@ -47,7 +47,7 @@ export function convertSvelteRoot(
   const fragment = getFragmentFromRoot(svelteAst);
   if (fragment) {
     let children = getChildren(fragment);
-    const options = getOptionsFromRoot(svelteAst);
+    const options = getOptionsFromRoot(svelteAst, ctx.code);
     if (options) {
       children = [...children];
       if (
@@ -212,7 +212,7 @@ function extractAttributes(
   const block = ctx.findBlock(element);
   if (block) {
     element.startTag.attributes.push(
-      ...convertAttributeTokens(block.attrs, element.startTag, ctx),
+      ...convertAttributes(block.attrs, element.startTag, ctx),
     );
   }
 }

--- a/src/parser/converts/root.ts
+++ b/src/parser/converts/root.ts
@@ -26,6 +26,7 @@ import {
   getModuleFromRoot,
   getOptionsFromRoot,
 } from "../compat";
+import { sortNodes } from "../sort";
 
 /**
  * Convert root
@@ -260,6 +261,7 @@ function convertGenericsAttribute(script: SvelteScriptElement, ctx: Context) {
   delete (genericsAttribute as any).value;
 
   // Remove value token indexes
+  sortNodes(ctx.tokens);
   const firstTokenIndex = ctx.tokens.findIndex(
     (token) =>
       value.range[0] <= token.range[0] && token.range[1] <= value.range[1],

--- a/src/parser/converts/root.ts
+++ b/src/parser/converts/root.ts
@@ -1,5 +1,5 @@
 import type * as SvAST from "../svelte-ast-types";
-import * as Compiler from "svelte/compiler";
+import type * as Compiler from "svelte/compiler";
 import type {
   SvelteAttribute,
   SvelteGenericsDirective,

--- a/src/parser/converts/text.ts
+++ b/src/parser/converts/text.ts
@@ -1,6 +1,5 @@
 import type { SvelteLiteral, SvelteText } from "../../ast";
 import type { Context } from "../../context";
-import type { AttributeValueToken } from "../html";
 import type * as SvAST from "../svelte-ast-types";
 /** Convert for Text */
 export function convertText(
@@ -31,25 +30,6 @@ export function convertTextToLiteral(
     ...ctx.getConvertLocation(node),
   };
   extractTextTokens(node, ctx);
-  return text;
-}
-
-/** Convert for AttributeValueToken to Literal */
-export function convertAttributeValueTokenToLiteral(
-  node: AttributeValueToken,
-  parent: SvelteLiteral["parent"],
-  ctx: Context,
-): SvelteLiteral {
-  const valueLoc = node.quote
-    ? { start: node.start + 1, end: node.end - 1 }
-    : node;
-  const text: SvelteLiteral = {
-    type: "SvelteLiteral",
-    value: node.value,
-    parent,
-    ...ctx.getConvertLocation(valueLoc),
-  };
-  extractTextTokens(valueLoc, ctx);
   return text;
 }
 

--- a/src/parser/espree.ts
+++ b/src/parser/espree.ts
@@ -19,7 +19,8 @@ const createRequire: (filename: string) => (modName: string) => any =
     return mod.exports;
   });
 
-let espreeCache: BasicParserObject | null = null;
+let espreeCache: (BasicParserObject & { latestEcmaVersion: number }) | null =
+  null;
 
 /** Checks if given path is linter path */
 function isLinterPath(p: string): boolean {
@@ -35,7 +36,7 @@ function isLinterPath(p: string): boolean {
  * Load `espree` from the loaded ESLint.
  * If the loaded ESLint was not found, just returns `require("espree")`.
  */
-export function getEspree(): BasicParserObject {
+export function getEspree(): BasicParserObject & { latestEcmaVersion: number } {
   if (!espreeCache) {
     // Lookup the loaded eslint
     const linterPath = Object.keys(require.cache || {}).find(isLinterPath);

--- a/src/parser/html.ts
+++ b/src/parser/html.ts
@@ -241,9 +241,11 @@ function parseAttributeMustache(state: State):
     if (state.eat("}")) {
       const end = endCandidate;
       try {
+        const espree = getEspree();
+
         const expression = (
-          getEspree().parse(state.code.slice(start, end), {
-            ecmaVersion: "latest",
+          espree.parse(state.code.slice(start, end), {
+            ecmaVersion: espree.latestEcmaVersion,
           }).body[0] as ESTree.ExpressionStatement
         ).expression;
         delete expression.range;

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -12,6 +12,7 @@ import type { ScopeManager } from "eslint-scope";
 import { Variable } from "eslint-scope";
 import { parseScript, parseScriptInSvelte } from "./script";
 import type * as SvAST from "./svelte-ast-types";
+import type * as Compiler from "svelte/compiler";
 import { sortNodes } from "./sort";
 import { parseTemplate } from "./template";
 import {
@@ -37,6 +38,7 @@ import { globals, globalsForSvelteScript } from "./globals";
 import { svelteVersion } from "./svelte-version";
 import type { NormalizedParserOptions } from "./parser-options";
 import { isTypeScript, normalizeParserOptions } from "./parser-options";
+import { getFragmentFromRoot } from "./compat";
 
 export {
   StyleContext,
@@ -70,7 +72,7 @@ type ParseResult = {
       | {
           isSvelte: true;
           isSvelteScript: false;
-          getSvelteHtmlAst: () => SvAST.Fragment;
+          getSvelteHtmlAst: () => SvAST.Fragment | Compiler.Fragment;
           getStyleContext: () => StyleContext;
         }
       | { isSvelte: false; isSvelteScript: true }
@@ -196,7 +198,7 @@ function parseAsSvelte(
     isSvelte: true,
     isSvelteScript: false,
     getSvelteHtmlAst() {
-      return resultTemplate.svelteAst.html;
+      return getFragmentFromRoot(resultTemplate.svelteAst);
     },
     getStyleContext() {
       if (styleContext === null) {

--- a/src/parser/svelte-ast-types.ts
+++ b/src/parser/svelte-ast-types.ts
@@ -1,13 +1,7 @@
 import type ESTree from "estree";
-import type * as Compiler from "svelte/compiler";
 interface BaseNode {
   start: number;
   end: number;
-}
-export interface Ast {
-  fragment?: Compiler.Fragment;
-  js: Compiler.Script[];
-  css?: Compiler.Style;
 }
 export interface AstLegacy {
   html?: Fragment;

--- a/src/parser/svelte-ast-types.ts
+++ b/src/parser/svelte-ast-types.ts
@@ -1,13 +1,19 @@
 import type ESTree from "estree";
+import type * as Compiler from "svelte/compiler";
 interface BaseNode {
   start: number;
   end: number;
 }
 export interface Ast {
-  html: Fragment;
-  css: Style;
-  instance: Script;
-  module: Script;
+  fragment?: Compiler.Fragment;
+  js: Compiler.Script[];
+  css?: Compiler.Style;
+}
+export interface AstLegacy {
+  html?: Fragment;
+  css?: Style;
+  instance?: Script;
+  module?: Script;
 }
 export declare type TemplateNode =
   | Text

--- a/src/parser/svelte-ast-types.ts
+++ b/src/parser/svelte-ast-types.ts
@@ -21,7 +21,6 @@ export declare type TemplateNode =
   | RawMustacheTag
   | DebugTag
   | ConstTag
-  | RenderTag
   | Directive
   | StyleDirective
   | Element
@@ -38,8 +37,7 @@ export declare type TemplateNode =
   | IfBlock
   | EachBlock
   | AwaitBlock
-  | KeyBlock
-  | SnippetBlock;
+  | KeyBlock;
 export interface Fragment extends BaseNode {
   type: "Fragment";
   children: TemplateNode[];
@@ -63,12 +61,6 @@ export interface DebugTag extends BaseNode {
 export interface ConstTag extends BaseNode {
   type: "ConstTag";
   expression: ESTree.AssignmentExpression;
-}
-export interface RenderTag extends BaseNode {
-  type: "RenderTag";
-  expression:
-    | ESTree.SimpleCallExpression
-    | (ESTree.ChainExpression & { expression: ESTree.SimpleCallExpression });
 }
 export interface IfBlock extends BaseNode {
   type: "IfBlock";
@@ -120,13 +112,6 @@ export interface KeyBlock extends BaseNode {
   expression: ESTree.Expression;
   children: TemplateNode[];
 }
-export interface SnippetBlock extends BaseNode {
-  type: "SnippetBlock";
-  expression: ESTree.Identifier;
-  parameters: ESTree.Pattern[];
-  children: TemplateNode[];
-}
-
 export interface BaseElement extends BaseNode {
   type: "Element";
   name: string;

--- a/src/parser/template.ts
+++ b/src/parser/template.ts
@@ -1,6 +1,6 @@
 import type {} from "svelte"; // FIXME: Workaround to get type information for "svelte/compiler"
 import { parse } from "svelte/compiler";
-import * as Compiler from "svelte/compiler";
+import type * as Compiler from "svelte/compiler";
 import type * as SvAST from "./svelte-ast-types";
 import type { Context } from "../context";
 import { convertSvelteRoot } from "./converts/index";

--- a/src/parser/template.ts
+++ b/src/parser/template.ts
@@ -7,6 +7,7 @@ import { sortNodes } from "./sort";
 import type { SvelteProgram } from "../ast";
 import { ParseError } from "..";
 import type { NormalizedParserOptions } from "./parser-options";
+import { svelteVersion } from "./svelte-version";
 
 /**
  * Parse for template
@@ -17,12 +18,13 @@ export function parseTemplate(
   parserOptions: NormalizedParserOptions,
 ): {
   ast: SvelteProgram;
-  svelteAst: SvAST.Ast;
+  svelteAst: SvAST.Ast | SvAST.AstLegacy;
 } {
   try {
     const svelteAst = parse(code, {
       filename: parserOptions.filePath,
-    }) as never as SvAST.Ast;
+      ...(svelteVersion.gte(5) ? { modern: true } : {}),
+    }) as never as SvAST.Ast | SvAST.AstLegacy;
     const ast = convertSvelteRoot(svelteAst, ctx);
     sortNodes(ast.body);
 

--- a/src/parser/template.ts
+++ b/src/parser/template.ts
@@ -1,5 +1,6 @@
 import type {} from "svelte"; // FIXME: Workaround to get type information for "svelte/compiler"
 import { parse } from "svelte/compiler";
+import * as Compiler from "svelte/compiler";
 import type * as SvAST from "./svelte-ast-types";
 import type { Context } from "../context";
 import { convertSvelteRoot } from "./converts/index";
@@ -18,13 +19,13 @@ export function parseTemplate(
   parserOptions: NormalizedParserOptions,
 ): {
   ast: SvelteProgram;
-  svelteAst: SvAST.Ast | SvAST.AstLegacy;
+  svelteAst: Compiler.Root | SvAST.AstLegacy;
 } {
   try {
     const svelteAst = parse(code, {
       filename: parserOptions.filePath,
       ...(svelteVersion.gte(5) ? { modern: true } : {}),
-    }) as never as SvAST.Ast | SvAST.AstLegacy;
+    }) as never as Compiler.Root | SvAST.AstLegacy;
     const ast = convertSvelteRoot(svelteAst, ctx);
     sortNodes(ast.body);
 

--- a/tests/fixtures/parser/ast/at-const02-input.svelte
+++ b/tests/fixtures/parser/ast/at-const02-input.svelte
@@ -1,0 +1,15 @@
+<script>
+export let boxes;
+</script>
+
+{#each boxes as box}
+{
+@const
+area
+=
+box.width
+*
+box.height
+}
+{box.width} * {box.height} = {area}
+{/each}

--- a/tests/fixtures/parser/ast/at-const02-output.json
+++ b/tests/fixtures/parser/ast/at-const02-output.json
@@ -1,0 +1,1617 @@
+{
+  "type": "Program",
+  "body": [
+    {
+      "type": "SvelteScriptElement",
+      "name": {
+        "type": "SvelteName",
+        "name": "script",
+        "range": [
+          1,
+          7
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        }
+      },
+      "startTag": {
+        "type": "SvelteStartTag",
+        "attributes": [],
+        "selfClosing": false,
+        "range": [
+          0,
+          8
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 8
+          }
+        }
+      },
+      "body": [
+        {
+          "type": "ExportNamedDeclaration",
+          "declaration": {
+            "type": "VariableDeclaration",
+            "kind": "let",
+            "declarations": [
+              {
+                "type": "VariableDeclarator",
+                "id": {
+                  "type": "Identifier",
+                  "name": "boxes",
+                  "range": [
+                    20,
+                    25
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 16
+                    }
+                  }
+                },
+                "init": null,
+                "range": [
+                  20,
+                  25
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 16
+                  }
+                }
+              }
+            ],
+            "range": [
+              16,
+              26
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 7
+              },
+              "end": {
+                "line": 2,
+                "column": 17
+              }
+            }
+          },
+          "source": null,
+          "specifiers": [],
+          "range": [
+            9,
+            26
+          ],
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 0
+            },
+            "end": {
+              "line": 2,
+              "column": 17
+            }
+          }
+        }
+      ],
+      "endTag": {
+        "type": "SvelteEndTag",
+        "range": [
+          27,
+          36
+        ],
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 9
+          }
+        }
+      },
+      "range": [
+        0,
+        36
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": "SvelteText",
+      "value": "\n\n",
+      "range": [
+        36,
+        38
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 9
+        },
+        "end": {
+          "line": 5,
+          "column": 0
+        }
+      }
+    },
+    {
+      "type": "SvelteEachBlock",
+      "expression": {
+        "type": "Identifier",
+        "name": "boxes",
+        "range": [
+          45,
+          50
+        ],
+        "loc": {
+          "start": {
+            "line": 5,
+            "column": 7
+          },
+          "end": {
+            "line": 5,
+            "column": 12
+          }
+        }
+      },
+      "context": {
+        "type": "Identifier",
+        "name": "box",
+        "range": [
+          54,
+          57
+        ],
+        "loc": {
+          "start": {
+            "line": 5,
+            "column": 16
+          },
+          "end": {
+            "line": 5,
+            "column": 19
+          }
+        }
+      },
+      "index": null,
+      "key": null,
+      "children": [
+        {
+          "type": "SvelteConstTag",
+          "declaration": {
+            "type": "VariableDeclarator",
+            "id": {
+              "type": "Identifier",
+              "name": "area",
+              "range": [
+                68,
+                72
+              ],
+              "loc": {
+                "start": {
+                  "line": 8,
+                  "column": 0
+                },
+                "end": {
+                  "line": 8,
+                  "column": 4
+                }
+              }
+            },
+            "init": {
+              "type": "BinaryExpression",
+              "left": {
+                "type": "MemberExpression",
+                "computed": false,
+                "object": {
+                  "type": "Identifier",
+                  "name": "box",
+                  "range": [
+                    75,
+                    78
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 10,
+                      "column": 0
+                    },
+                    "end": {
+                      "line": 10,
+                      "column": 3
+                    }
+                  }
+                },
+                "optional": false,
+                "property": {
+                  "type": "Identifier",
+                  "name": "width",
+                  "range": [
+                    79,
+                    84
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 10,
+                      "column": 4
+                    },
+                    "end": {
+                      "line": 10,
+                      "column": 9
+                    }
+                  }
+                },
+                "range": [
+                  75,
+                  84
+                ],
+                "loc": {
+                  "start": {
+                    "line": 10,
+                    "column": 0
+                  },
+                  "end": {
+                    "line": 10,
+                    "column": 9
+                  }
+                }
+              },
+              "operator": "*",
+              "right": {
+                "type": "MemberExpression",
+                "computed": false,
+                "object": {
+                  "type": "Identifier",
+                  "name": "box",
+                  "range": [
+                    87,
+                    90
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 12,
+                      "column": 0
+                    },
+                    "end": {
+                      "line": 12,
+                      "column": 3
+                    }
+                  }
+                },
+                "optional": false,
+                "property": {
+                  "type": "Identifier",
+                  "name": "height",
+                  "range": [
+                    91,
+                    97
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 12,
+                      "column": 4
+                    },
+                    "end": {
+                      "line": 12,
+                      "column": 10
+                    }
+                  }
+                },
+                "range": [
+                  87,
+                  97
+                ],
+                "loc": {
+                  "start": {
+                    "line": 12,
+                    "column": 0
+                  },
+                  "end": {
+                    "line": 12,
+                    "column": 10
+                  }
+                }
+              },
+              "range": [
+                75,
+                97
+              ],
+              "loc": {
+                "start": {
+                  "line": 10,
+                  "column": 0
+                },
+                "end": {
+                  "line": 12,
+                  "column": 10
+                }
+              }
+            },
+            "range": [
+              68,
+              97
+            ],
+            "loc": {
+              "start": {
+                "line": 8,
+                "column": 0
+              },
+              "end": {
+                "line": 12,
+                "column": 10
+              }
+            }
+          },
+          "range": [
+            59,
+            99
+          ],
+          "loc": {
+            "start": {
+              "line": 6,
+              "column": 0
+            },
+            "end": {
+              "line": 13,
+              "column": 1
+            }
+          }
+        },
+        {
+          "type": "SvelteText",
+          "value": "\n",
+          "range": [
+            99,
+            100
+          ],
+          "loc": {
+            "start": {
+              "line": 13,
+              "column": 1
+            },
+            "end": {
+              "line": 14,
+              "column": 0
+            }
+          }
+        },
+        {
+          "type": "SvelteMustacheTag",
+          "kind": "text",
+          "expression": {
+            "type": "MemberExpression",
+            "computed": false,
+            "object": {
+              "type": "Identifier",
+              "name": "box",
+              "range": [
+                101,
+                104
+              ],
+              "loc": {
+                "start": {
+                  "line": 14,
+                  "column": 1
+                },
+                "end": {
+                  "line": 14,
+                  "column": 4
+                }
+              }
+            },
+            "optional": false,
+            "property": {
+              "type": "Identifier",
+              "name": "width",
+              "range": [
+                105,
+                110
+              ],
+              "loc": {
+                "start": {
+                  "line": 14,
+                  "column": 5
+                },
+                "end": {
+                  "line": 14,
+                  "column": 10
+                }
+              }
+            },
+            "range": [
+              101,
+              110
+            ],
+            "loc": {
+              "start": {
+                "line": 14,
+                "column": 1
+              },
+              "end": {
+                "line": 14,
+                "column": 10
+              }
+            }
+          },
+          "range": [
+            100,
+            111
+          ],
+          "loc": {
+            "start": {
+              "line": 14,
+              "column": 0
+            },
+            "end": {
+              "line": 14,
+              "column": 11
+            }
+          }
+        },
+        {
+          "type": "SvelteText",
+          "value": " * ",
+          "range": [
+            111,
+            114
+          ],
+          "loc": {
+            "start": {
+              "line": 14,
+              "column": 11
+            },
+            "end": {
+              "line": 14,
+              "column": 14
+            }
+          }
+        },
+        {
+          "type": "SvelteMustacheTag",
+          "kind": "text",
+          "expression": {
+            "type": "MemberExpression",
+            "computed": false,
+            "object": {
+              "type": "Identifier",
+              "name": "box",
+              "range": [
+                115,
+                118
+              ],
+              "loc": {
+                "start": {
+                  "line": 14,
+                  "column": 15
+                },
+                "end": {
+                  "line": 14,
+                  "column": 18
+                }
+              }
+            },
+            "optional": false,
+            "property": {
+              "type": "Identifier",
+              "name": "height",
+              "range": [
+                119,
+                125
+              ],
+              "loc": {
+                "start": {
+                  "line": 14,
+                  "column": 19
+                },
+                "end": {
+                  "line": 14,
+                  "column": 25
+                }
+              }
+            },
+            "range": [
+              115,
+              125
+            ],
+            "loc": {
+              "start": {
+                "line": 14,
+                "column": 15
+              },
+              "end": {
+                "line": 14,
+                "column": 25
+              }
+            }
+          },
+          "range": [
+            114,
+            126
+          ],
+          "loc": {
+            "start": {
+              "line": 14,
+              "column": 14
+            },
+            "end": {
+              "line": 14,
+              "column": 26
+            }
+          }
+        },
+        {
+          "type": "SvelteText",
+          "value": " = ",
+          "range": [
+            126,
+            129
+          ],
+          "loc": {
+            "start": {
+              "line": 14,
+              "column": 26
+            },
+            "end": {
+              "line": 14,
+              "column": 29
+            }
+          }
+        },
+        {
+          "type": "SvelteMustacheTag",
+          "kind": "text",
+          "expression": {
+            "type": "Identifier",
+            "name": "area",
+            "range": [
+              130,
+              134
+            ],
+            "loc": {
+              "start": {
+                "line": 14,
+                "column": 30
+              },
+              "end": {
+                "line": 14,
+                "column": 34
+              }
+            }
+          },
+          "range": [
+            129,
+            135
+          ],
+          "loc": {
+            "start": {
+              "line": 14,
+              "column": 29
+            },
+            "end": {
+              "line": 14,
+              "column": 35
+            }
+          }
+        }
+      ],
+      "else": null,
+      "range": [
+        38,
+        143
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 0
+        },
+        "end": {
+          "line": 15,
+          "column": 7
+        }
+      }
+    }
+  ],
+  "sourceType": "module",
+  "comments": [],
+  "tokens": [
+    {
+      "type": "Punctuator",
+      "value": "<",
+      "range": [
+        0,
+        1
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "script",
+      "range": [
+        1,
+        7
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 1,
+          "column": 7
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ">",
+      "range": [
+        7,
+        8
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 7
+        },
+        "end": {
+          "line": 1,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": "Keyword",
+      "value": "export",
+      "range": [
+        9,
+        15
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 0
+        },
+        "end": {
+          "line": 2,
+          "column": 6
+        }
+      }
+    },
+    {
+      "type": "Keyword",
+      "value": "let",
+      "range": [
+        16,
+        19
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 7
+        },
+        "end": {
+          "line": 2,
+          "column": 10
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "boxes",
+      "range": [
+        20,
+        25
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 11
+        },
+        "end": {
+          "line": 2,
+          "column": 16
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ";",
+      "range": [
+        25,
+        26
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 16
+        },
+        "end": {
+          "line": 2,
+          "column": 17
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "<",
+      "range": [
+        27,
+        28
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "/",
+      "range": [
+        28,
+        29
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 1
+        },
+        "end": {
+          "line": 3,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "script",
+      "range": [
+        29,
+        35
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 2
+        },
+        "end": {
+          "line": 3,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ">",
+      "range": [
+        35,
+        36
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 8
+        },
+        "end": {
+          "line": 3,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": "HTMLText",
+      "value": "\n\n",
+      "range": [
+        36,
+        38
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 9
+        },
+        "end": {
+          "line": 5,
+          "column": 0
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        38,
+        39
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 0
+        },
+        "end": {
+          "line": 5,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "MustacheKeyword",
+      "value": "#each",
+      "range": [
+        39,
+        44
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 1
+        },
+        "end": {
+          "line": 5,
+          "column": 6
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "boxes",
+      "range": [
+        45,
+        50
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 7
+        },
+        "end": {
+          "line": 5,
+          "column": 12
+        }
+      }
+    },
+    {
+      "type": "Keyword",
+      "value": "as",
+      "range": [
+        51,
+        53
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 13
+        },
+        "end": {
+          "line": 5,
+          "column": 15
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "box",
+      "range": [
+        54,
+        57
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 16
+        },
+        "end": {
+          "line": 5,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        57,
+        58
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 19
+        },
+        "end": {
+          "line": 5,
+          "column": 20
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        59,
+        60
+      ],
+      "loc": {
+        "start": {
+          "line": 6,
+          "column": 0
+        },
+        "end": {
+          "line": 6,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "MustacheKeyword",
+      "value": "@const",
+      "range": [
+        61,
+        67
+      ],
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 0
+        },
+        "end": {
+          "line": 7,
+          "column": 6
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "area",
+      "range": [
+        68,
+        72
+      ],
+      "loc": {
+        "start": {
+          "line": 8,
+          "column": 0
+        },
+        "end": {
+          "line": 8,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "=",
+      "range": [
+        73,
+        74
+      ],
+      "loc": {
+        "start": {
+          "line": 9,
+          "column": 0
+        },
+        "end": {
+          "line": 9,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "box",
+      "range": [
+        75,
+        78
+      ],
+      "loc": {
+        "start": {
+          "line": 10,
+          "column": 0
+        },
+        "end": {
+          "line": 10,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ".",
+      "range": [
+        78,
+        79
+      ],
+      "loc": {
+        "start": {
+          "line": 10,
+          "column": 3
+        },
+        "end": {
+          "line": 10,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "width",
+      "range": [
+        79,
+        84
+      ],
+      "loc": {
+        "start": {
+          "line": 10,
+          "column": 4
+        },
+        "end": {
+          "line": 10,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "*",
+      "range": [
+        85,
+        86
+      ],
+      "loc": {
+        "start": {
+          "line": 11,
+          "column": 0
+        },
+        "end": {
+          "line": 11,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "box",
+      "range": [
+        87,
+        90
+      ],
+      "loc": {
+        "start": {
+          "line": 12,
+          "column": 0
+        },
+        "end": {
+          "line": 12,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ".",
+      "range": [
+        90,
+        91
+      ],
+      "loc": {
+        "start": {
+          "line": 12,
+          "column": 3
+        },
+        "end": {
+          "line": 12,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "height",
+      "range": [
+        91,
+        97
+      ],
+      "loc": {
+        "start": {
+          "line": 12,
+          "column": 4
+        },
+        "end": {
+          "line": 12,
+          "column": 10
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        98,
+        99
+      ],
+      "loc": {
+        "start": {
+          "line": 13,
+          "column": 0
+        },
+        "end": {
+          "line": 13,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "HTMLText",
+      "value": "\n",
+      "range": [
+        99,
+        100
+      ],
+      "loc": {
+        "start": {
+          "line": 13,
+          "column": 1
+        },
+        "end": {
+          "line": 14,
+          "column": 0
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        100,
+        101
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 0
+        },
+        "end": {
+          "line": 14,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "box",
+      "range": [
+        101,
+        104
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 1
+        },
+        "end": {
+          "line": 14,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ".",
+      "range": [
+        104,
+        105
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 4
+        },
+        "end": {
+          "line": 14,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "width",
+      "range": [
+        105,
+        110
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 5
+        },
+        "end": {
+          "line": 14,
+          "column": 10
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        110,
+        111
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 10
+        },
+        "end": {
+          "line": 14,
+          "column": 11
+        }
+      }
+    },
+    {
+      "type": "HTMLText",
+      "value": " ",
+      "range": [
+        111,
+        112
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 11
+        },
+        "end": {
+          "line": 14,
+          "column": 12
+        }
+      }
+    },
+    {
+      "type": "HTMLText",
+      "value": "*",
+      "range": [
+        112,
+        113
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 12
+        },
+        "end": {
+          "line": 14,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": "HTMLText",
+      "value": " ",
+      "range": [
+        113,
+        114
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 13
+        },
+        "end": {
+          "line": 14,
+          "column": 14
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        114,
+        115
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 14
+        },
+        "end": {
+          "line": 14,
+          "column": 15
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "box",
+      "range": [
+        115,
+        118
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 15
+        },
+        "end": {
+          "line": 14,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ".",
+      "range": [
+        118,
+        119
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 18
+        },
+        "end": {
+          "line": 14,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "height",
+      "range": [
+        119,
+        125
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 19
+        },
+        "end": {
+          "line": 14,
+          "column": 25
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        125,
+        126
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 25
+        },
+        "end": {
+          "line": 14,
+          "column": 26
+        }
+      }
+    },
+    {
+      "type": "HTMLText",
+      "value": " ",
+      "range": [
+        126,
+        127
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 26
+        },
+        "end": {
+          "line": 14,
+          "column": 27
+        }
+      }
+    },
+    {
+      "type": "HTMLText",
+      "value": "=",
+      "range": [
+        127,
+        128
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 27
+        },
+        "end": {
+          "line": 14,
+          "column": 28
+        }
+      }
+    },
+    {
+      "type": "HTMLText",
+      "value": " ",
+      "range": [
+        128,
+        129
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 28
+        },
+        "end": {
+          "line": 14,
+          "column": 29
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        129,
+        130
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 29
+        },
+        "end": {
+          "line": 14,
+          "column": 30
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "area",
+      "range": [
+        130,
+        134
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 30
+        },
+        "end": {
+          "line": 14,
+          "column": 34
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        134,
+        135
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 34
+        },
+        "end": {
+          "line": 14,
+          "column": 35
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        136,
+        137
+      ],
+      "loc": {
+        "start": {
+          "line": 15,
+          "column": 0
+        },
+        "end": {
+          "line": 15,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "MustacheKeyword",
+      "value": "/each",
+      "range": [
+        137,
+        142
+      ],
+      "loc": {
+        "start": {
+          "line": 15,
+          "column": 1
+        },
+        "end": {
+          "line": 15,
+          "column": 6
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        142,
+        143
+      ],
+      "loc": {
+        "start": {
+          "line": 15,
+          "column": 6
+        },
+        "end": {
+          "line": 15,
+          "column": 7
+        }
+      }
+    }
+  ],
+  "range": [
+    0,
+    144
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 16,
+      "column": 0
+    }
+  }
+}

--- a/tests/fixtures/parser/ast/at-const02-scope-output.json
+++ b/tests/fixtures/parser/ast/at-const02-scope-output.json
@@ -1,0 +1,1463 @@
+{
+  "type": "global",
+  "variables": [
+    {
+      "name": "$$slots",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$props",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$restProps",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    }
+  ],
+  "references": [],
+  "childScopes": [
+    {
+      "type": "module",
+      "variables": [
+        {
+          "name": "boxes",
+          "identifiers": [
+            {
+              "type": "Identifier",
+              "name": "boxes",
+              "range": [
+                20,
+                25
+              ],
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 11
+                },
+                "end": {
+                  "line": 2,
+                  "column": 16
+                }
+              }
+            }
+          ],
+          "defs": [
+            {
+              "type": "Variable",
+              "name": {
+                "type": "Identifier",
+                "name": "boxes",
+                "range": [
+                  20,
+                  25
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 16
+                  }
+                }
+              },
+              "node": {
+                "type": "VariableDeclarator",
+                "id": {
+                  "type": "Identifier",
+                  "name": "boxes",
+                  "range": [
+                    20,
+                    25
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 16
+                    }
+                  }
+                },
+                "init": null,
+                "range": [
+                  20,
+                  25
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 16
+                  }
+                }
+              }
+            }
+          ],
+          "references": [
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "boxes",
+                "range": [
+                  20,
+                  25
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 16
+                  }
+                }
+              },
+              "from": "module",
+              "init": null,
+              "resolved": {
+                "type": "Identifier",
+                "name": "boxes",
+                "range": [
+                  20,
+                  25
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 16
+                  }
+                }
+              }
+            },
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "boxes",
+                "range": [
+                  45,
+                  50
+                ],
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 12
+                  }
+                }
+              },
+              "from": "module",
+              "init": null,
+              "resolved": {
+                "type": "Identifier",
+                "name": "boxes",
+                "range": [
+                  20,
+                  25
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 16
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "references": [
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "boxes",
+            "range": [
+              45,
+              50
+            ],
+            "loc": {
+              "start": {
+                "line": 5,
+                "column": 7
+              },
+              "end": {
+                "line": 5,
+                "column": 12
+              }
+            }
+          },
+          "from": "module",
+          "init": null,
+          "resolved": {
+            "type": "Identifier",
+            "name": "boxes",
+            "range": [
+              20,
+              25
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 11
+              },
+              "end": {
+                "line": 2,
+                "column": 16
+              }
+            }
+          }
+        }
+      ],
+      "childScopes": [
+        {
+          "type": "function",
+          "variables": [
+            {
+              "name": "box",
+              "identifiers": [
+                {
+                  "type": "Identifier",
+                  "name": "box",
+                  "range": [
+                    54,
+                    57
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 16
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 19
+                    }
+                  }
+                }
+              ],
+              "defs": [
+                {
+                  "type": "Parameter",
+                  "name": {
+                    "type": "Identifier",
+                    "name": "box",
+                    "range": [
+                      54,
+                      57
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 19
+                      }
+                    }
+                  },
+                  "node": {
+                    "type": "SvelteEachBlock",
+                    "expression": {
+                      "type": "Identifier",
+                      "name": "boxes",
+                      "range": [
+                        45,
+                        50
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 5,
+                          "column": 7
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 12
+                        }
+                      }
+                    },
+                    "context": {
+                      "type": "Identifier",
+                      "name": "box",
+                      "range": [
+                        54,
+                        57
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 5,
+                          "column": 16
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 19
+                        }
+                      }
+                    },
+                    "index": null,
+                    "key": null,
+                    "children": [
+                      {
+                        "type": "SvelteConstTag",
+                        "declaration": {
+                          "type": "VariableDeclarator",
+                          "id": {
+                            "type": "Identifier",
+                            "name": "area",
+                            "range": [
+                              68,
+                              72
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 8,
+                                "column": 0
+                              },
+                              "end": {
+                                "line": 8,
+                                "column": 4
+                              }
+                            }
+                          },
+                          "init": {
+                            "type": "BinaryExpression",
+                            "left": {
+                              "type": "MemberExpression",
+                              "computed": false,
+                              "object": {
+                                "type": "Identifier",
+                                "name": "box",
+                                "range": [
+                                  75,
+                                  78
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 10,
+                                    "column": 0
+                                  },
+                                  "end": {
+                                    "line": 10,
+                                    "column": 3
+                                  }
+                                }
+                              },
+                              "optional": false,
+                              "property": {
+                                "type": "Identifier",
+                                "name": "width",
+                                "range": [
+                                  79,
+                                  84
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 10,
+                                    "column": 4
+                                  },
+                                  "end": {
+                                    "line": 10,
+                                    "column": 9
+                                  }
+                                }
+                              },
+                              "range": [
+                                75,
+                                84
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 10,
+                                  "column": 0
+                                },
+                                "end": {
+                                  "line": 10,
+                                  "column": 9
+                                }
+                              }
+                            },
+                            "operator": "*",
+                            "right": {
+                              "type": "MemberExpression",
+                              "computed": false,
+                              "object": {
+                                "type": "Identifier",
+                                "name": "box",
+                                "range": [
+                                  87,
+                                  90
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 12,
+                                    "column": 0
+                                  },
+                                  "end": {
+                                    "line": 12,
+                                    "column": 3
+                                  }
+                                }
+                              },
+                              "optional": false,
+                              "property": {
+                                "type": "Identifier",
+                                "name": "height",
+                                "range": [
+                                  91,
+                                  97
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 12,
+                                    "column": 4
+                                  },
+                                  "end": {
+                                    "line": 12,
+                                    "column": 10
+                                  }
+                                }
+                              },
+                              "range": [
+                                87,
+                                97
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 12,
+                                  "column": 0
+                                },
+                                "end": {
+                                  "line": 12,
+                                  "column": 10
+                                }
+                              }
+                            },
+                            "range": [
+                              75,
+                              97
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 10,
+                                "column": 0
+                              },
+                              "end": {
+                                "line": 12,
+                                "column": 10
+                              }
+                            }
+                          },
+                          "range": [
+                            68,
+                            97
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 8,
+                              "column": 0
+                            },
+                            "end": {
+                              "line": 12,
+                              "column": 10
+                            }
+                          }
+                        },
+                        "range": [
+                          59,
+                          99
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 6,
+                            "column": 0
+                          },
+                          "end": {
+                            "line": 13,
+                            "column": 1
+                          }
+                        }
+                      },
+                      {
+                        "type": "SvelteText",
+                        "value": "\n",
+                        "range": [
+                          99,
+                          100
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 13,
+                            "column": 1
+                          },
+                          "end": {
+                            "line": 14,
+                            "column": 0
+                          }
+                        }
+                      },
+                      {
+                        "type": "SvelteMustacheTag",
+                        "kind": "text",
+                        "expression": {
+                          "type": "MemberExpression",
+                          "computed": false,
+                          "object": {
+                            "type": "Identifier",
+                            "name": "box",
+                            "range": [
+                              101,
+                              104
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 14,
+                                "column": 1
+                              },
+                              "end": {
+                                "line": 14,
+                                "column": 4
+                              }
+                            }
+                          },
+                          "optional": false,
+                          "property": {
+                            "type": "Identifier",
+                            "name": "width",
+                            "range": [
+                              105,
+                              110
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 14,
+                                "column": 5
+                              },
+                              "end": {
+                                "line": 14,
+                                "column": 10
+                              }
+                            }
+                          },
+                          "range": [
+                            101,
+                            110
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 14,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 14,
+                              "column": 10
+                            }
+                          }
+                        },
+                        "range": [
+                          100,
+                          111
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 14,
+                            "column": 0
+                          },
+                          "end": {
+                            "line": 14,
+                            "column": 11
+                          }
+                        }
+                      },
+                      {
+                        "type": "SvelteText",
+                        "value": " * ",
+                        "range": [
+                          111,
+                          114
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 14,
+                            "column": 11
+                          },
+                          "end": {
+                            "line": 14,
+                            "column": 14
+                          }
+                        }
+                      },
+                      {
+                        "type": "SvelteMustacheTag",
+                        "kind": "text",
+                        "expression": {
+                          "type": "MemberExpression",
+                          "computed": false,
+                          "object": {
+                            "type": "Identifier",
+                            "name": "box",
+                            "range": [
+                              115,
+                              118
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 14,
+                                "column": 15
+                              },
+                              "end": {
+                                "line": 14,
+                                "column": 18
+                              }
+                            }
+                          },
+                          "optional": false,
+                          "property": {
+                            "type": "Identifier",
+                            "name": "height",
+                            "range": [
+                              119,
+                              125
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 14,
+                                "column": 19
+                              },
+                              "end": {
+                                "line": 14,
+                                "column": 25
+                              }
+                            }
+                          },
+                          "range": [
+                            115,
+                            125
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 14,
+                              "column": 15
+                            },
+                            "end": {
+                              "line": 14,
+                              "column": 25
+                            }
+                          }
+                        },
+                        "range": [
+                          114,
+                          126
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 14,
+                            "column": 14
+                          },
+                          "end": {
+                            "line": 14,
+                            "column": 26
+                          }
+                        }
+                      },
+                      {
+                        "type": "SvelteText",
+                        "value": " = ",
+                        "range": [
+                          126,
+                          129
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 14,
+                            "column": 26
+                          },
+                          "end": {
+                            "line": 14,
+                            "column": 29
+                          }
+                        }
+                      },
+                      {
+                        "type": "SvelteMustacheTag",
+                        "kind": "text",
+                        "expression": {
+                          "type": "Identifier",
+                          "name": "area",
+                          "range": [
+                            130,
+                            134
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 14,
+                              "column": 30
+                            },
+                            "end": {
+                              "line": 14,
+                              "column": 34
+                            }
+                          }
+                        },
+                        "range": [
+                          129,
+                          135
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 14,
+                            "column": 29
+                          },
+                          "end": {
+                            "line": 14,
+                            "column": 35
+                          }
+                        }
+                      }
+                    ],
+                    "else": null,
+                    "range": [
+                      38,
+                      143
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 0
+                      },
+                      "end": {
+                        "line": 15,
+                        "column": 7
+                      }
+                    }
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "identifier": {
+                    "type": "Identifier",
+                    "name": "box",
+                    "range": [
+                      75,
+                      78
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 10,
+                        "column": 0
+                      },
+                      "end": {
+                        "line": 10,
+                        "column": 3
+                      }
+                    }
+                  },
+                  "from": "function",
+                  "init": null,
+                  "resolved": {
+                    "type": "Identifier",
+                    "name": "box",
+                    "range": [
+                      54,
+                      57
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 19
+                      }
+                    }
+                  }
+                },
+                {
+                  "identifier": {
+                    "type": "Identifier",
+                    "name": "box",
+                    "range": [
+                      87,
+                      90
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 12,
+                        "column": 0
+                      },
+                      "end": {
+                        "line": 12,
+                        "column": 3
+                      }
+                    }
+                  },
+                  "from": "function",
+                  "init": null,
+                  "resolved": {
+                    "type": "Identifier",
+                    "name": "box",
+                    "range": [
+                      54,
+                      57
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 19
+                      }
+                    }
+                  }
+                },
+                {
+                  "identifier": {
+                    "type": "Identifier",
+                    "name": "box",
+                    "range": [
+                      101,
+                      104
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 14,
+                        "column": 1
+                      },
+                      "end": {
+                        "line": 14,
+                        "column": 4
+                      }
+                    }
+                  },
+                  "from": "function",
+                  "init": null,
+                  "resolved": {
+                    "type": "Identifier",
+                    "name": "box",
+                    "range": [
+                      54,
+                      57
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 19
+                      }
+                    }
+                  }
+                },
+                {
+                  "identifier": {
+                    "type": "Identifier",
+                    "name": "box",
+                    "range": [
+                      115,
+                      118
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 14,
+                        "column": 15
+                      },
+                      "end": {
+                        "line": 14,
+                        "column": 18
+                      }
+                    }
+                  },
+                  "from": "function",
+                  "init": null,
+                  "resolved": {
+                    "type": "Identifier",
+                    "name": "box",
+                    "range": [
+                      54,
+                      57
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 19
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "name": "area",
+              "identifiers": [
+                {
+                  "type": "Identifier",
+                  "name": "area",
+                  "range": [
+                    68,
+                    72
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 8,
+                      "column": 0
+                    },
+                    "end": {
+                      "line": 8,
+                      "column": 4
+                    }
+                  }
+                }
+              ],
+              "defs": [
+                {
+                  "type": "Variable",
+                  "name": {
+                    "type": "Identifier",
+                    "name": "area",
+                    "range": [
+                      68,
+                      72
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 8,
+                        "column": 0
+                      },
+                      "end": {
+                        "line": 8,
+                        "column": 4
+                      }
+                    }
+                  },
+                  "node": {
+                    "type": "VariableDeclarator",
+                    "id": {
+                      "type": "Identifier",
+                      "name": "area",
+                      "range": [
+                        68,
+                        72
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 8,
+                          "column": 0
+                        },
+                        "end": {
+                          "line": 8,
+                          "column": 4
+                        }
+                      }
+                    },
+                    "init": {
+                      "type": "BinaryExpression",
+                      "left": {
+                        "type": "MemberExpression",
+                        "computed": false,
+                        "object": {
+                          "type": "Identifier",
+                          "name": "box",
+                          "range": [
+                            75,
+                            78
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 10,
+                              "column": 0
+                            },
+                            "end": {
+                              "line": 10,
+                              "column": 3
+                            }
+                          }
+                        },
+                        "optional": false,
+                        "property": {
+                          "type": "Identifier",
+                          "name": "width",
+                          "range": [
+                            79,
+                            84
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 10,
+                              "column": 4
+                            },
+                            "end": {
+                              "line": 10,
+                              "column": 9
+                            }
+                          }
+                        },
+                        "range": [
+                          75,
+                          84
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 10,
+                            "column": 0
+                          },
+                          "end": {
+                            "line": 10,
+                            "column": 9
+                          }
+                        }
+                      },
+                      "operator": "*",
+                      "right": {
+                        "type": "MemberExpression",
+                        "computed": false,
+                        "object": {
+                          "type": "Identifier",
+                          "name": "box",
+                          "range": [
+                            87,
+                            90
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 12,
+                              "column": 0
+                            },
+                            "end": {
+                              "line": 12,
+                              "column": 3
+                            }
+                          }
+                        },
+                        "optional": false,
+                        "property": {
+                          "type": "Identifier",
+                          "name": "height",
+                          "range": [
+                            91,
+                            97
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 12,
+                              "column": 4
+                            },
+                            "end": {
+                              "line": 12,
+                              "column": 10
+                            }
+                          }
+                        },
+                        "range": [
+                          87,
+                          97
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 12,
+                            "column": 0
+                          },
+                          "end": {
+                            "line": 12,
+                            "column": 10
+                          }
+                        }
+                      },
+                      "range": [
+                        75,
+                        97
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 10,
+                          "column": 0
+                        },
+                        "end": {
+                          "line": 12,
+                          "column": 10
+                        }
+                      }
+                    },
+                    "range": [
+                      68,
+                      97
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 8,
+                        "column": 0
+                      },
+                      "end": {
+                        "line": 12,
+                        "column": 10
+                      }
+                    }
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "identifier": {
+                    "type": "Identifier",
+                    "name": "area",
+                    "range": [
+                      68,
+                      72
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 8,
+                        "column": 0
+                      },
+                      "end": {
+                        "line": 8,
+                        "column": 4
+                      }
+                    }
+                  },
+                  "from": "function",
+                  "init": true,
+                  "resolved": {
+                    "type": "Identifier",
+                    "name": "area",
+                    "range": [
+                      68,
+                      72
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 8,
+                        "column": 0
+                      },
+                      "end": {
+                        "line": 8,
+                        "column": 4
+                      }
+                    }
+                  }
+                },
+                {
+                  "identifier": {
+                    "type": "Identifier",
+                    "name": "area",
+                    "range": [
+                      130,
+                      134
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 14,
+                        "column": 30
+                      },
+                      "end": {
+                        "line": 14,
+                        "column": 34
+                      }
+                    }
+                  },
+                  "from": "function",
+                  "init": null,
+                  "resolved": {
+                    "type": "Identifier",
+                    "name": "area",
+                    "range": [
+                      68,
+                      72
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 8,
+                        "column": 0
+                      },
+                      "end": {
+                        "line": 8,
+                        "column": 4
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "references": [
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "area",
+                "range": [
+                  68,
+                  72
+                ],
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 0
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 4
+                  }
+                }
+              },
+              "from": "function",
+              "init": true,
+              "resolved": {
+                "type": "Identifier",
+                "name": "area",
+                "range": [
+                  68,
+                  72
+                ],
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 0
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 4
+                  }
+                }
+              }
+            },
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "box",
+                "range": [
+                  75,
+                  78
+                ],
+                "loc": {
+                  "start": {
+                    "line": 10,
+                    "column": 0
+                  },
+                  "end": {
+                    "line": 10,
+                    "column": 3
+                  }
+                }
+              },
+              "from": "function",
+              "init": null,
+              "resolved": {
+                "type": "Identifier",
+                "name": "box",
+                "range": [
+                  54,
+                  57
+                ],
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 19
+                  }
+                }
+              }
+            },
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "box",
+                "range": [
+                  87,
+                  90
+                ],
+                "loc": {
+                  "start": {
+                    "line": 12,
+                    "column": 0
+                  },
+                  "end": {
+                    "line": 12,
+                    "column": 3
+                  }
+                }
+              },
+              "from": "function",
+              "init": null,
+              "resolved": {
+                "type": "Identifier",
+                "name": "box",
+                "range": [
+                  54,
+                  57
+                ],
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 19
+                  }
+                }
+              }
+            },
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "box",
+                "range": [
+                  101,
+                  104
+                ],
+                "loc": {
+                  "start": {
+                    "line": 14,
+                    "column": 1
+                  },
+                  "end": {
+                    "line": 14,
+                    "column": 4
+                  }
+                }
+              },
+              "from": "function",
+              "init": null,
+              "resolved": {
+                "type": "Identifier",
+                "name": "box",
+                "range": [
+                  54,
+                  57
+                ],
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 19
+                  }
+                }
+              }
+            },
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "box",
+                "range": [
+                  115,
+                  118
+                ],
+                "loc": {
+                  "start": {
+                    "line": 14,
+                    "column": 15
+                  },
+                  "end": {
+                    "line": 14,
+                    "column": 18
+                  }
+                }
+              },
+              "from": "function",
+              "init": null,
+              "resolved": {
+                "type": "Identifier",
+                "name": "box",
+                "range": [
+                  54,
+                  57
+                ],
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 19
+                  }
+                }
+              }
+            },
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "area",
+                "range": [
+                  130,
+                  134
+                ],
+                "loc": {
+                  "start": {
+                    "line": 14,
+                    "column": 30
+                  },
+                  "end": {
+                    "line": 14,
+                    "column": 34
+                  }
+                }
+              },
+              "from": "function",
+              "init": null,
+              "resolved": {
+                "type": "Identifier",
+                "name": "area",
+                "range": [
+                  68,
+                  72
+                ],
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 0
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 4
+                  }
+                }
+              }
+            }
+          ],
+          "childScopes": [],
+          "through": []
+        }
+      ],
+      "through": []
+    }
+  ],
+  "through": []
+}

--- a/tests/fixtures/parser/ast/await03-requirements.json
+++ b/tests/fixtures/parser/ast/await03-requirements.json
@@ -1,6 +1,0 @@
-{
-	"FIXME": "As of now, Svelte v5 gives an error with single-line await blocks.",
-	"parse": {
-		"svelte": "^4 || ^3"
-	}
-}

--- a/tests/src/parser/__snapshots__/html.ts.snap
+++ b/tests/src/parser/__snapshots__/html.ts.snap
@@ -11,17 +11,22 @@ exports[`parseAttributes <script lang="ts"> 1`] = `
 Object {
   "attributes": Array [
     Object {
-      "key": Object {
-        "end": 12,
-        "name": "lang",
-        "start": 8,
-      },
-      "value": Object {
-        "end": 17,
-        "quote": "\\"",
-        "start": 13,
-        "value": "ts",
-      },
+      "end": 17,
+      "metadata": null,
+      "name": "lang",
+      "parent": null,
+      "start": 8,
+      "type": "Attribute",
+      "value": Array [
+        Object {
+          "data": "ts",
+          "end": 16,
+          "parent": null,
+          "raw": "ts",
+          "start": 14,
+          "type": "Text",
+        },
+      ],
     },
   ],
   "index": 17,
@@ -32,17 +37,22 @@ exports[`parseAttributes <script lang='ts'> 1`] = `
 Object {
   "attributes": Array [
     Object {
-      "key": Object {
-        "end": 12,
-        "name": "lang",
-        "start": 8,
-      },
-      "value": Object {
-        "end": 17,
-        "quote": "'",
-        "start": 13,
-        "value": "ts",
-      },
+      "end": 17,
+      "metadata": null,
+      "name": "lang",
+      "parent": null,
+      "start": 8,
+      "type": "Attribute",
+      "value": Array [
+        Object {
+          "data": "ts",
+          "end": 16,
+          "parent": null,
+          "raw": "ts",
+          "start": 14,
+          "type": "Text",
+        },
+      ],
     },
   ],
   "index": 17,
@@ -53,17 +63,22 @@ exports[`parseAttributes <script lang=ts> 1`] = `
 Object {
   "attributes": Array [
     Object {
-      "key": Object {
-        "end": 12,
-        "name": "lang",
-        "start": 8,
-      },
-      "value": Object {
-        "end": 15,
-        "quote": null,
-        "start": 13,
-        "value": "ts",
-      },
+      "end": 15,
+      "metadata": null,
+      "name": "lang",
+      "parent": null,
+      "start": 8,
+      "type": "Attribute",
+      "value": Array [
+        Object {
+          "data": "ts",
+          "end": 15,
+          "parent": null,
+          "raw": "ts",
+          "start": 13,
+          "type": "Text",
+        },
+      ],
     },
   ],
   "index": 15,
@@ -74,12 +89,13 @@ exports[`parseAttributes <style global/> 1`] = `
 Object {
   "attributes": Array [
     Object {
-      "key": Object {
-        "end": 13,
-        "name": "global",
-        "start": 7,
-      },
-      "value": null,
+      "end": 13,
+      "metadata": null,
+      "name": "global",
+      "parent": null,
+      "start": 7,
+      "type": "Attribute",
+      "value": true,
     },
   ],
   "index": 13,
@@ -90,12 +106,13 @@ exports[`parseAttributes <style global> 1`] = `
 Object {
   "attributes": Array [
     Object {
-      "key": Object {
-        "end": 13,
-        "name": "global",
-        "start": 7,
-      },
-      "value": null,
+      "end": 13,
+      "metadata": null,
+      "name": "global",
+      "parent": null,
+      "start": 7,
+      "type": "Attribute",
+      "value": true,
     },
   ],
   "index": 13,
@@ -106,12 +123,13 @@ exports[`parseAttributes attr   1`] = `
 Object {
   "attributes": Array [
     Object {
-      "key": Object {
-        "end": 4,
-        "name": "attr",
-        "start": 0,
-      },
-      "value": null,
+      "end": 4,
+      "metadata": null,
+      "name": "attr",
+      "parent": null,
+      "start": 0,
+      "type": "Attribute",
+      "value": true,
     },
   ],
   "index": 6,
@@ -122,17 +140,22 @@ exports[`parseAttributes attr  =  "value" 1`] = `
 Object {
   "attributes": Array [
     Object {
-      "key": Object {
-        "end": 4,
-        "name": "attr",
-        "start": 0,
-      },
-      "value": Object {
-        "end": 16,
-        "quote": "\\"",
-        "start": 9,
-        "value": "value",
-      },
+      "end": 16,
+      "metadata": null,
+      "name": "attr",
+      "parent": null,
+      "start": 0,
+      "type": "Attribute",
+      "value": Array [
+        Object {
+          "data": "value",
+          "end": 15,
+          "parent": null,
+          "raw": "value",
+          "start": 10,
+          "type": "Text",
+        },
+      ],
     },
   ],
   "index": 16,
@@ -143,12 +166,13 @@ exports[`parseAttributes attr 1`] = `
 Object {
   "attributes": Array [
     Object {
-      "key": Object {
-        "end": 4,
-        "name": "attr",
-        "start": 0,
-      },
-      "value": null,
+      "end": 4,
+      "metadata": null,
+      "name": "attr",
+      "parent": null,
+      "start": 0,
+      "type": "Attribute",
+      "value": true,
     },
   ],
   "index": 4,
@@ -159,17 +183,22 @@ exports[`parseAttributes attr="value" 1`] = `
 Object {
   "attributes": Array [
     Object {
-      "key": Object {
-        "end": 4,
-        "name": "attr",
-        "start": 0,
-      },
-      "value": Object {
-        "end": 12,
-        "quote": "\\"",
-        "start": 5,
-        "value": "value",
-      },
+      "end": 12,
+      "metadata": null,
+      "name": "attr",
+      "parent": null,
+      "start": 0,
+      "type": "Attribute",
+      "value": Array [
+        Object {
+          "data": "value",
+          "end": 11,
+          "parent": null,
+          "raw": "value",
+          "start": 6,
+          "type": "Text",
+        },
+      ],
     },
   ],
   "index": 12,
@@ -180,17 +209,22 @@ exports[`parseAttributes empty=""   1`] = `
 Object {
   "attributes": Array [
     Object {
-      "key": Object {
-        "end": 5,
-        "name": "empty",
-        "start": 0,
-      },
-      "value": Object {
-        "end": 8,
-        "quote": "\\"",
-        "start": 6,
-        "value": "",
-      },
+      "end": 8,
+      "metadata": null,
+      "name": "empty",
+      "parent": null,
+      "start": 0,
+      "type": "Attribute",
+      "value": Array [
+        Object {
+          "data": "",
+          "end": 7,
+          "parent": null,
+          "raw": "",
+          "start": 7,
+          "type": "Text",
+        },
+      ],
     },
   ],
   "index": 10,
@@ -201,20 +235,277 @@ exports[`parseAttributes empty=''   1`] = `
 Object {
   "attributes": Array [
     Object {
-      "key": Object {
-        "end": 5,
-        "name": "empty",
-        "start": 0,
-      },
-      "value": Object {
-        "end": 8,
-        "quote": "'",
-        "start": 6,
-        "value": "",
-      },
+      "end": 8,
+      "metadata": null,
+      "name": "empty",
+      "parent": null,
+      "start": 0,
+      "type": "Attribute",
+      "value": Array [
+        Object {
+          "data": "",
+          "end": 7,
+          "parent": null,
+          "raw": "",
+          "start": 7,
+          "type": "Text",
+        },
+      ],
     },
   ],
   "index": 10,
+}
+`;
+
+exports[`parseAttributes expr="{true}"   1`] = `
+Object {
+  "attributes": Array [
+    Object {
+      "end": 13,
+      "metadata": null,
+      "name": "expr",
+      "parent": null,
+      "start": 0,
+      "type": "Attribute",
+      "value": Array [
+        Object {
+          "end": 13,
+          "expression": Object {
+            "end": 11,
+            "leadingComments": Array [],
+            "raw": "true",
+            "start": 7,
+            "type": "Literal",
+            "value": true,
+          },
+          "metadata": null,
+          "parent": null,
+          "start": 5,
+          "type": "ExpressionTag",
+        },
+      ],
+    },
+  ],
+  "index": 15,
+}
+`;
+
+exports[`parseAttributes expr='{true}'   1`] = `
+Object {
+  "attributes": Array [
+    Object {
+      "end": 13,
+      "metadata": null,
+      "name": "expr",
+      "parent": null,
+      "start": 0,
+      "type": "Attribute",
+      "value": Array [
+        Object {
+          "end": 13,
+          "expression": Object {
+            "end": 11,
+            "leadingComments": Array [],
+            "raw": "true",
+            "start": 7,
+            "type": "Literal",
+            "value": true,
+          },
+          "metadata": null,
+          "parent": null,
+          "start": 5,
+          "type": "ExpressionTag",
+        },
+      ],
+    },
+  ],
+  "index": 15,
+}
+`;
+
+exports[`parseAttributes expr={"}"}   1`] = `
+Object {
+  "attributes": Array [
+    Object {
+      "end": 10,
+      "metadata": null,
+      "name": "expr",
+      "parent": null,
+      "start": 0,
+      "type": "Attribute",
+      "value": Array [
+        Object {
+          "end": 10,
+          "expression": Object {
+            "end": 9,
+            "leadingComments": Array [],
+            "raw": "\\"}\\"",
+            "start": 6,
+            "type": "Literal",
+            "value": "}",
+          },
+          "metadata": null,
+          "parent": null,
+          "start": 5,
+          "type": "ExpressionTag",
+        },
+      ],
+    },
+  ],
+  "index": 12,
+}
+`;
+
+exports[`parseAttributes expr={"s"}   1`] = `
+Object {
+  "attributes": Array [
+    Object {
+      "end": 10,
+      "metadata": null,
+      "name": "expr",
+      "parent": null,
+      "start": 0,
+      "type": "Attribute",
+      "value": Array [
+        Object {
+          "end": 10,
+          "expression": Object {
+            "end": 9,
+            "leadingComments": Array [],
+            "raw": "\\"s\\"",
+            "start": 6,
+            "type": "Literal",
+            "value": "s",
+          },
+          "metadata": null,
+          "parent": null,
+          "start": 5,
+          "type": "ExpressionTag",
+        },
+      ],
+    },
+  ],
+  "index": 12,
+}
+`;
+
+exports[`parseAttributes expr={/*}*/"}"}   1`] = `
+Object {
+  "attributes": Array [
+    Object {
+      "end": 15,
+      "metadata": null,
+      "name": "expr",
+      "parent": null,
+      "start": 0,
+      "type": "Attribute",
+      "value": Array [
+        Object {
+          "end": 15,
+          "expression": Object {
+            "end": 14,
+            "leadingComments": Array [
+              Object {
+                "end": 11,
+                "start": 6,
+                "type": "Block",
+                "value": "}",
+              },
+            ],
+            "raw": "\\"}\\"",
+            "start": 11,
+            "type": "Literal",
+            "value": "}",
+          },
+          "metadata": null,
+          "parent": null,
+          "start": 5,
+          "type": "ExpressionTag",
+        },
+      ],
+    },
+  ],
+  "index": 17,
+}
+`;
+
+exports[`parseAttributes expr={/*}*///}
+"}"}   1`] = `
+Object {
+  "attributes": Array [
+    Object {
+      "end": 19,
+      "metadata": null,
+      "name": "expr",
+      "parent": null,
+      "start": 0,
+      "type": "Attribute",
+      "value": Array [
+        Object {
+          "end": 19,
+          "expression": Object {
+            "end": 18,
+            "leadingComments": Array [
+              Object {
+                "end": 11,
+                "start": 6,
+                "type": "Block",
+                "value": "}",
+              },
+              Object {
+                "end": 15,
+                "start": 11,
+                "type": "Line",
+                "value": "}",
+              },
+            ],
+            "raw": "\\"}\\"",
+            "start": 15,
+            "type": "Literal",
+            "value": "}",
+          },
+          "metadata": null,
+          "parent": null,
+          "start": 5,
+          "type": "ExpressionTag",
+        },
+      ],
+    },
+  ],
+  "index": 21,
+}
+`;
+
+exports[`parseAttributes expr={true}   1`] = `
+Object {
+  "attributes": Array [
+    Object {
+      "end": 11,
+      "metadata": null,
+      "name": "expr",
+      "parent": null,
+      "start": 0,
+      "type": "Attribute",
+      "value": Array [
+        Object {
+          "end": 11,
+          "expression": Object {
+            "end": 10,
+            "leadingComments": Array [],
+            "raw": "true",
+            "start": 6,
+            "type": "Literal",
+            "value": true,
+          },
+          "metadata": null,
+          "parent": null,
+          "start": 5,
+          "type": "ExpressionTag",
+        },
+      ],
+    },
+  ],
+  "index": 13,
 }
 `;
 
@@ -222,17 +513,22 @@ exports[`parseAttributes quote="'"   1`] = `
 Object {
   "attributes": Array [
     Object {
-      "key": Object {
-        "end": 5,
-        "name": "quote",
-        "start": 0,
-      },
-      "value": Object {
-        "end": 9,
-        "quote": "\\"",
-        "start": 6,
-        "value": "'",
-      },
+      "end": 9,
+      "metadata": null,
+      "name": "quote",
+      "parent": null,
+      "start": 0,
+      "type": "Attribute",
+      "value": Array [
+        Object {
+          "data": "'",
+          "end": 8,
+          "parent": null,
+          "raw": "'",
+          "start": 7,
+          "type": "Text",
+        },
+      ],
     },
   ],
   "index": 11,
@@ -243,17 +539,22 @@ exports[`parseAttributes quote='"'   1`] = `
 Object {
   "attributes": Array [
     Object {
-      "key": Object {
-        "end": 5,
-        "name": "quote",
-        "start": 0,
-      },
-      "value": Object {
-        "end": 9,
-        "quote": "'",
-        "start": 6,
-        "value": "\\"",
-      },
+      "end": 9,
+      "metadata": null,
+      "name": "quote",
+      "parent": null,
+      "start": 0,
+      "type": "Attribute",
+      "value": Array [
+        Object {
+          "data": "\\"",
+          "end": 8,
+          "parent": null,
+          "raw": "\\"",
+          "start": 7,
+          "type": "Text",
+        },
+      ],
     },
   ],
   "index": 11,

--- a/tests/src/parser/html.ts
+++ b/tests/src/parser/html.ts
@@ -53,6 +53,27 @@ describe("parseAttributes", () => {
     {
       input: `quote='"'  `,
     },
+    {
+      input: `expr={true}  `,
+    },
+    {
+      input: `expr="{true}"  `,
+    },
+    {
+      input: `expr='{true}'  `,
+    },
+    {
+      input: `expr={"s"}  `,
+    },
+    {
+      input: `expr={"}"}  `,
+    },
+    {
+      input: `expr={/*}*/"}"}  `,
+    },
+    {
+      input: `expr={/*}*///}\n"}"}  `,
+    },
   ];
   for (const { input, index } of testCases) {
     it(input || "(empty)", () => {

--- a/tests/src/parser/test-utils.ts
+++ b/tests/src/parser/test-utils.ts
@@ -157,6 +157,10 @@ function writeScopeFile(
     /input\.svelte(?:\.[jt]s)?$/u,
     "scope-output.json",
   );
+  const scopeFileNameSvelte5 = inputFileName.replace(
+    /input\.svelte(?:\.[jt]s)?$/u,
+    "scope-output-svelte5.json",
+  );
   if (!svelteVersion.gte(5)) {
     // v4
     if (isSvelte5Only) return;
@@ -167,12 +171,11 @@ function writeScopeFile(
   // v5
   if (isSvelte5Only) {
     fs.writeFileSync(scopeFileName, json, "utf8");
+    if (fs.existsSync(scopeFileNameSvelte5)) {
+      fs.unlinkSync(scopeFileNameSvelte5);
+    }
     return;
   }
-  const scopeFileNameSvelte5 = inputFileName.replace(
-    /input\.svelte(?:\.[jt]s)?$/u,
-    "scope-output-svelte5.json",
-  );
   if (!fs.existsSync(scopeFileName)) {
     fs.writeFileSync(scopeFileNameSvelte5, json, "utf8");
     return;
@@ -185,6 +188,9 @@ function writeScopeFile(
       variables: SVELTE5_SCOPE_VARIABLES_BASE,
     }) === JSON.stringify(scope)
   ) {
+    if (fs.existsSync(scopeFileNameSvelte5)) {
+      fs.unlinkSync(scopeFileNameSvelte5);
+    }
     return;
   }
 

--- a/tests/src/parser/typescript/assert-result.ts
+++ b/tests/src/parser/typescript/assert-result.ts
@@ -1,4 +1,3 @@
-/* eslint complexity: 0 -- debug */
 /** Assert equals */
 export function assertResult(
   aRoot: unknown,


### PR DESCRIPTION
This PR will be changed to also use Svelte v5's modern AST.
I believe this has performance benefits as it allows we to skip the transformation step to legacy AST.