### PR TITLE
chore: turn off eslint complexity rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
     "no-shadow": "off",
     "no-warning-comments": "warn",
     "require-jsdoc": "off",
+    complexity: "off",
     "prettier/prettier": [
       "error",
       {},

--- a/src/parser/converts/element.ts
+++ b/src/parser/converts/element.ts
@@ -52,10 +52,8 @@ import type { ScriptLetBlockParam } from "../../context/script-let";
 import { ParseError } from "../..";
 import { convertRenderTag } from "./render";
 
-/* eslint-disable complexity -- X */
 /** Convert for Fragment or Element or ... */
 export function* convertChildren(
-  /* eslint-enable complexity -- X */
   fragment: { children?: SvAST.TemplateNode[] },
   parent:
     | SvelteProgram

--- a/src/parser/typescript/analyze/index.ts
+++ b/src/parser/typescript/analyze/index.ts
@@ -817,55 +817,53 @@ function transformForDollarDerived(
 
   ctx.restoreContext.addRestoreExpressionProcess<TSESTree.CallExpression>({
     target: "CallExpression" as TSESTree.AST_NODE_TYPES.CallExpression,
-    restore:
-      // eslint-disable-next-line complexity -- ignore
-      (node, result) => {
-        if (
-          node.callee.type !== "Identifier" ||
-          node.callee.name !== "$derived"
-        ) {
-          return false;
-        }
-        const arg = node.arguments[0];
-        if (
-          !arg ||
-          arg.type !== "CallExpression" ||
-          arg.arguments.length !== 0 ||
-          arg.callee.type !== "ArrowFunctionExpression" ||
-          arg.callee.body.type !== "BlockStatement" ||
-          arg.callee.body.body.length !== 2 ||
-          arg.callee.body.body[0].type !== "ReturnStatement" ||
-          arg.callee.body.body[0].argument?.type !== "CallExpression" ||
-          arg.callee.body.body[0].argument.callee.type !== "Identifier" ||
-          arg.callee.body.body[0].argument.callee.name !== functionId ||
-          arg.callee.body.body[1].type !== "FunctionDeclaration" ||
-          arg.callee.body.body[1].id.name !== functionId
-        ) {
-          return false;
-        }
-        const fnNode = arg.callee.body.body[1];
-        if (
-          fnNode.body.body.length !== 1 ||
-          fnNode.body.body[0].type !== "ReturnStatement" ||
-          !fnNode.body.body[0].argument
-        ) {
-          return false;
-        }
+    restore: (node, result) => {
+      if (
+        node.callee.type !== "Identifier" ||
+        node.callee.name !== "$derived"
+      ) {
+        return false;
+      }
+      const arg = node.arguments[0];
+      if (
+        !arg ||
+        arg.type !== "CallExpression" ||
+        arg.arguments.length !== 0 ||
+        arg.callee.type !== "ArrowFunctionExpression" ||
+        arg.callee.body.type !== "BlockStatement" ||
+        arg.callee.body.body.length !== 2 ||
+        arg.callee.body.body[0].type !== "ReturnStatement" ||
+        arg.callee.body.body[0].argument?.type !== "CallExpression" ||
+        arg.callee.body.body[0].argument.callee.type !== "Identifier" ||
+        arg.callee.body.body[0].argument.callee.name !== functionId ||
+        arg.callee.body.body[1].type !== "FunctionDeclaration" ||
+        arg.callee.body.body[1].id.name !== functionId
+      ) {
+        return false;
+      }
+      const fnNode = arg.callee.body.body[1];
+      if (
+        fnNode.body.body.length !== 1 ||
+        fnNode.body.body[0].type !== "ReturnStatement" ||
+        !fnNode.body.body[0].argument
+      ) {
+        return false;
+      }
 
-        const expr = fnNode.body.body[0].argument;
+      const expr = fnNode.body.body[0].argument;
 
-        node.arguments[0] = expr;
-        expr.parent = node;
+      node.arguments[0] = expr;
+      expr.parent = node;
 
-        const scopeManager = result.scopeManager as ScopeManager;
-        removeFunctionScope(arg.callee.body.body[1], scopeManager);
-        removeIdentifierReference(
-          arg.callee.body.body[0].argument.callee,
-          scopeManager.acquire(arg.callee)!,
-        );
-        removeFunctionScope(arg.callee, scopeManager);
-        return true;
-      },
+      const scopeManager = result.scopeManager as ScopeManager;
+      removeFunctionScope(arg.callee.body.body[1], scopeManager);
+      removeIdentifierReference(
+        arg.callee.body.body[0].argument.callee,
+        scopeManager.acquire(arg.callee)!,
+      );
+      removeFunctionScope(arg.callee, scopeManager);
+      return true;
+    },
   });
 }
 

--- a/src/parser/typescript/analyze/index.ts
+++ b/src/parser/typescript/analyze/index.ts
@@ -647,7 +647,6 @@ function transformForDeclareReactiveVar(
   ctx.appendOriginal(statement.range[1]);
   ctx.appendVirtualScript(`}`);
 
-  // eslint-disable-next-line complexity -- ignore X(
   ctx.restoreContext.addRestoreStatementProcess((node, result) => {
     if ((node as any).type !== "SvelteReactiveStatement") {
       return false;

--- a/src/scope/index.ts
+++ b/src/scope/index.ts
@@ -90,10 +90,8 @@ export function getProgramScope(scopeManager: ScopeManager): Scope {
   );
 }
 
-/* eslint-disable complexity -- ignore X( */
 /** Remove variable */
 export function removeIdentifierVariable(
-  /* eslint-enable complexity -- ignore X( */
   node:
     | ESTree.Pattern
     | TSESTree.BindingName

--- a/tests/src/parser/test-utils.ts
+++ b/tests/src/parser/test-utils.ts
@@ -513,15 +513,10 @@ export function normalizeError(error: any): any {
   };
 }
 
-/* eslint-disable complexity -- ignore */
 /**
  * Remove `parent` properties from the given AST.
  */
-function nodeReplacer(
-  /* eslint-enable complexity -- ignore */
-  key: string,
-  value: any,
-): any {
+function nodeReplacer(key: string, value: any): any {
   if (key === "parent") {
     return undefined;
   }


### PR DESCRIPTION
I've been using `complexity` for a long time, but since you often need to suppress rules to do type guarding well using typescript, I thought it would be better to turn this rule off. 