### PR TITLE
chore: drop `@typescript-eslint` v4 support

### DIFF
--- a/.changeset/eighty-books-study.md
+++ b/.changeset/eighty-books-study.md
@@ -1,0 +1,5 @@
+---
+"svelte-eslint-parser": minor
+---
+
+breaking: drop @typescript-eslint v4 support

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -103,26 +103,6 @@ jobs:
         run: pnpm install
       - name: Test
         run: pnpm run test
-  test-for-ts-eslint-v4:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [14.x]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Install @typescript-eslint v4
-        run: |+
-          pnpm install -D @typescript-eslint/parser@4 @typescript-eslint/eslint-plugin@4 eslint@7 svelte@3
-          rm -rf node_modules
-      - name: Install Packages
-        run: pnpm install
-      - name: Test
-        run: pnpm run test
   test-for-eslint-v7:
     runs-on: ubuntu-latest
     strategy:

--- a/src/context/script-let.ts
+++ b/src/context/script-let.ts
@@ -352,7 +352,7 @@ export class ScriptLetContext {
         const callArrayFrom = (call.callee as ESTree.MemberExpression)
           .object as ESTree.CallExpression;
         const expr = callArrayFrom.arguments[0] as ESTree.Expression;
-        const ctx = fn.params[0]!;
+        const ctx = fn.params[0];
         const idx = (fn.params[1] ?? null) as ESTree.Identifier | null;
         const scope = result.getScope(fn.body);
 


### PR DESCRIPTION
We can not merge https://github.com/sveltejs/svelte-eslint-parser/pull/399 if we continue to support `@typescript-eslint` v4.

`@typescript-eslint` v5 was released on October 12, 2021. (https://github.com/typescript-eslint/typescript-eslint/releases/tag/v5.0.0)
The number of v4 downloads is 1.9% of v6 downloads, but I believe that many of those are CIs from ecosystems such as ours.

![image](https://github.com/sveltejs/svelte-eslint-parser/assets/19153718/e0798634-0b21-4d72-ac00-5a447b8d1c87)

![image](https://github.com/sveltejs/svelte-eslint-parser/assets/19153718/03e1ec7c-3da5-415e-b984-bceb0eac83a3)

We can merge https://github.com/sveltejs/svelte-eslint-parser/pull/399 after merge this PR.
