### PR TITLE
feat: change AST of `{@render}` and `{#snippet}` to match the latest version of svelte v5.

### DIFF
--- a/.changeset/yellow-hornets-bow.md
+++ b/.changeset/yellow-hornets-bow.md
@@ -2,4 +2,4 @@
 "svelte-eslint-parser": minor
 ---
 
-feat: change AST of `@render` tag to match the latest version of svelte v5.
+feat: change AST of `{@render}` and `{#snippet}` to match the latest version of svelte v5.

--- a/.changeset/yellow-hornets-bow.md
+++ b/.changeset/yellow-hornets-bow.md
@@ -1,0 +1,5 @@
+---
+"svelte-eslint-parser": minor
+---
+
+feat: change AST of `@render` tag to match the latest version of svelte v5.

--- a/docs/AST.md
+++ b/docs/AST.md
@@ -423,6 +423,8 @@ interface SvelteConstTag extends Node {
 }
 ```
 
+[VariableDeclarator] is a node defined in ESTree.
+
 ### SvelteRenderTag
 
 This is the `{@render}` tag node.
@@ -431,11 +433,9 @@ This is the `{@render}` tag node.
 interface SvelteRenderTag extends Node {
   type: "SvelteRenderTag";
   callee: Identifier;
-  argument: Expression | null;
+  arguments: (Expression | SpreadElement)[];
 }
 ```
-
-[VariableDeclarator] is a node defined in ESTree.
 
 ### SvelteIfBlock
 

--- a/docs/AST.md
+++ b/docs/AST.md
@@ -555,7 +555,7 @@ This is the `{#snippet}` tag node.
 interface SvelteSnippetBlock extends Node {
   type: "SvelteSnippetBlock";
   id: Identifier;
-  context: null | Pattern;
+  params: Pattern[];
   children: Child[];
 }
 ```

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "version:ci": "env-cmd -e version-ci pnpm run build:meta && changeset version"
   },
   "peerDependencies": {
-    "svelte": "^3.37.0 || ^4.0.0 || ^5.0.0-next.37"
+    "svelte": "^3.37.0 || ^4.0.0 || ^5.0.0-next.65"
   },
   "peerDependenciesMeta": {
     "svelte": {
@@ -105,7 +105,7 @@
     "prettier-plugin-svelte": "^3.1.2",
     "rimraf": "^5.0.5",
     "semver": "^7.5.4",
-    "svelte": "^5.0.0-next.37",
+    "svelte": "^5.0.0-next.65",
     "svelte2tsx": "^0.7.0",
     "typescript": "~5.3.0",
     "typescript-eslint-parser-for-extra-files": "^0.6.0"

--- a/src/ast/html.ts
+++ b/src/ast/html.ts
@@ -480,7 +480,7 @@ export interface SvelteKeyBlock extends BaseNode {
 export interface SvelteSnippetBlock extends BaseNode {
   type: "SvelteSnippetBlock";
   id: ESTree.Identifier;
-  context: null | ESTree.Pattern;
+  params: ESTree.Pattern[];
   children: Child[];
   parent:
     | SvelteProgram

--- a/src/ast/html.ts
+++ b/src/ast/html.ts
@@ -277,7 +277,7 @@ export interface SvelteConstTag extends BaseNode {
 export interface SvelteRenderTag extends BaseNode {
   type: "SvelteRenderTag";
   callee: ESTree.Identifier;
-  argument: ESTree.Expression | null;
+  arguments: (ESTree.Expression | ESTree.SpreadElement)[];
   parent:
     | SvelteProgram
     | SvelteElement

--- a/src/context/script-let.ts
+++ b/src/context/script-let.ts
@@ -428,7 +428,7 @@ export class ScriptLetContext {
     id: ESTree.Identifier,
     closeParentIndex: number,
     snippetBlock: SvelteSnippetBlock,
-    callback: (id: ESTree.Identifier, ctx: ESTree.Pattern | null) => void,
+    callback: (id: ESTree.Identifier, params: ESTree.Pattern[]) => void,
   ): void {
     const idRange = getNodeRange(id);
     const part = this.ctx.code.slice(idRange[0], closeParentIndex + 1);
@@ -438,14 +438,14 @@ export class ScriptLetContext {
       (st, tokens, _comments, result) => {
         const fnDecl = st as ESTree.FunctionDeclaration;
         const idNode = fnDecl.id;
-        const context = fnDecl.params.length > 0 ? fnDecl.params[0] : null;
+        const params = [...fnDecl.params];
         const scope = result.getScope(fnDecl);
 
         // Process for nodes
-        callback(idNode, context);
+        callback(idNode, params);
         (idNode as any).parent = snippetBlock;
-        if (context) {
-          (context as any).parent = snippetBlock;
+        for (const param of params) {
+          (param as any).parent = snippetBlock;
         }
 
         // Process for scope

--- a/src/parser/converts/block.ts
+++ b/src/parser/converts/block.ts
@@ -462,7 +462,7 @@ export function convertSnippetBlock(
   const snippetBlock: SvelteSnippetBlock = {
     type: "SvelteSnippetBlock",
     id: null as any,
-    context: null as any,
+    params: [],
     children: [],
     parent,
     ...ctx.getConvertLocation({ start: nodeStart, end: node.end }),
@@ -470,16 +470,20 @@ export function convertSnippetBlock(
 
   const closeParenIndex = ctx.code.indexOf(
     ")",
-    getWithLoc(node.context || node.expression).end,
+    getWithLoc(
+      node.parameters.length > 0
+        ? node.parameters[node.parameters.length - 1]
+        : node.expression,
+    ).end,
   );
 
   ctx.scriptLet.nestSnippetBlock(
     node.expression,
     closeParenIndex,
     snippetBlock,
-    (id, context) => {
+    (id, params) => {
       snippetBlock.id = id;
-      snippetBlock.context = context;
+      snippetBlock.params = params;
     },
   );
 

--- a/src/parser/converts/render.ts
+++ b/src/parser/converts/render.ts
@@ -13,14 +13,16 @@ export function convertRenderTag(
   const mustache: SvelteRenderTag = {
     type: "SvelteRenderTag",
     callee: null as any,
-    argument: null,
+    arguments: [],
     parent,
     ...ctx.getConvertLocation(node),
   };
   const calleeRange = getWithLoc(node.expression);
   const closeParenIndex = ctx.code.indexOf(
     ")",
-    node.argument ? getWithLoc(node.argument).end : calleeRange.end,
+    node.arguments.length
+      ? getWithLoc(node.arguments[node.arguments.length - 1]).end
+      : calleeRange.end,
   );
   ctx.scriptLet.addExpressionFromRange(
     [calleeRange.start, closeParenIndex + 1],
@@ -29,9 +31,9 @@ export function convertRenderTag(
     (expression: ESTree.SimpleCallExpression) => {
       mustache.callee = expression.callee as ESTree.Identifier;
       (mustache.callee as any).parent = mustache;
-      if (expression.arguments.length) {
-        mustache.argument = expression.arguments[0] as ESTree.Expression;
-        (mustache.argument as any).parent = mustache;
+      for (const argument of expression.arguments) {
+        mustache.arguments.push(argument);
+        (argument as any).parent = mustache;
       }
     },
   );

--- a/src/parser/svelte-ast-types.ts
+++ b/src/parser/svelte-ast-types.ts
@@ -116,7 +116,7 @@ export interface KeyBlock extends BaseNode {
 export interface SnippetBlock extends BaseNode {
   type: "SnippetBlock";
   expression: ESTree.Identifier;
-  context: null | ESTree.Pattern;
+  parameters: ESTree.Pattern[];
   children: TemplateNode[];
 }
 

--- a/src/parser/svelte-ast-types.ts
+++ b/src/parser/svelte-ast-types.ts
@@ -61,7 +61,7 @@ export interface ConstTag extends BaseNode {
 export interface RenderTag extends BaseNode {
   type: "RenderTag";
   expression: ESTree.Identifier;
-  argument: null | ESTree.Expression;
+  arguments: (ESTree.Expression | ESTree.SpreadElement)[];
 }
 export interface IfBlock extends BaseNode {
   type: "IfBlock";

--- a/src/visitor-keys.ts
+++ b/src/visitor-keys.ts
@@ -22,7 +22,7 @@ const svelteKeys: SvelteKeysType = {
   SvelteMustacheTag: ["expression"],
   SvelteDebugTag: ["identifiers"],
   SvelteConstTag: ["declaration"],
-  SvelteRenderTag: ["callee", "argument"],
+  SvelteRenderTag: ["callee", "arguments"],
   SvelteIfBlock: ["expression", "children", "else"],
   SvelteElseBlock: ["children"],
   SvelteEachBlock: [

--- a/src/visitor-keys.ts
+++ b/src/visitor-keys.ts
@@ -38,7 +38,7 @@ const svelteKeys: SvelteKeysType = {
   SvelteAwaitThenBlock: ["value", "children"],
   SvelteAwaitCatchBlock: ["error", "children"],
   SvelteKeyBlock: ["expression", "children"],
-  SvelteSnippetBlock: ["id", "context", "children"],
+  SvelteSnippetBlock: ["id", "params", "children"],
   SvelteAttribute: ["key", "value"],
   SvelteShorthandAttribute: ["key", "value"],
   SvelteSpreadAttribute: ["argument"],

--- a/tests/fixtures/parser/ast/svelte5/docs/snippets/01-output.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/snippets/01-output.json
@@ -1124,24 +1124,26 @@
                 },
                 {
                   "type": "SvelteRenderTag",
-                  "argument": {
-                    "type": "Identifier",
-                    "name": "image",
-                    "range": [
-                      288,
-                      293
-                    ],
-                    "loc": {
-                      "start": {
-                        "line": 16,
-                        "column": 19
-                      },
-                      "end": {
-                        "line": 16,
-                        "column": 24
+                  "arguments": [
+                    {
+                      "type": "Identifier",
+                      "name": "image",
+                      "range": [
+                        288,
+                        293
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 16,
+                          "column": 19
+                        },
+                        "end": {
+                          "line": 16,
+                          "column": 24
+                        }
                       }
                     }
-                  },
+                  ],
                   "callee": {
                     "type": "Identifier",
                     "name": "figure",
@@ -1233,24 +1235,26 @@
             "children": [
               {
                 "type": "SvelteRenderTag",
-                "argument": {
-                  "type": "Identifier",
-                  "name": "image",
-                  "range": [
-                    330,
-                    335
-                  ],
-                  "loc": {
-                    "start": {
-                      "line": 19,
-                      "column": 18
-                    },
-                    "end": {
-                      "line": 19,
-                      "column": 23
+                "arguments": [
+                  {
+                    "type": "Identifier",
+                    "name": "image",
+                    "range": [
+                      330,
+                      335
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 19,
+                        "column": 18
+                      },
+                      "end": {
+                        "line": 19,
+                        "column": 23
+                      }
                     }
                   }
-                },
+                ],
                 "callee": {
                   "type": "Identifier",
                   "name": "figure",

--- a/tests/fixtures/parser/ast/svelte5/docs/snippets/01-output.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/snippets/01-output.json
@@ -782,24 +782,6 @@
           }
         }
       ],
-      "context": {
-        "type": "Identifier",
-        "name": "image",
-        "range": [
-          17,
-          22
-        ],
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 17
-          },
-          "end": {
-            "line": 1,
-            "column": 22
-          }
-        }
-      },
       "id": {
         "type": "Identifier",
         "name": "figure",
@@ -818,6 +800,26 @@
           }
         }
       },
+      "params": [
+        {
+          "type": "Identifier",
+          "name": "image",
+          "range": [
+            17,
+            22
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 17
+            },
+            "end": {
+              "line": 1,
+              "column": 22
+            }
+          }
+        }
+      ],
       "range": [
         0,
         201

--- a/tests/fixtures/parser/ast/svelte5/docs/snippets/01-scope-output.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/snippets/01-scope-output.json
@@ -1254,24 +1254,26 @@
                               },
                               {
                                 "type": "SvelteRenderTag",
-                                "argument": {
-                                  "type": "Identifier",
-                                  "name": "image",
-                                  "range": [
-                                    288,
-                                    293
-                                  ],
-                                  "loc": {
-                                    "start": {
-                                      "line": 16,
-                                      "column": 19
-                                    },
-                                    "end": {
-                                      "line": 16,
-                                      "column": 24
+                                "arguments": [
+                                  {
+                                    "type": "Identifier",
+                                    "name": "image",
+                                    "range": [
+                                      288,
+                                      293
+                                    ],
+                                    "loc": {
+                                      "start": {
+                                        "line": 16,
+                                        "column": 19
+                                      },
+                                      "end": {
+                                        "line": 16,
+                                        "column": 24
+                                      }
                                     }
                                   }
-                                },
+                                ],
                                 "callee": {
                                   "type": "Identifier",
                                   "name": "figure",
@@ -1363,24 +1365,26 @@
                           "children": [
                             {
                               "type": "SvelteRenderTag",
-                              "argument": {
-                                "type": "Identifier",
-                                "name": "image",
-                                "range": [
-                                  330,
-                                  335
-                                ],
-                                "loc": {
-                                  "start": {
-                                    "line": 19,
-                                    "column": 18
-                                  },
-                                  "end": {
-                                    "line": 19,
-                                    "column": 23
+                              "arguments": [
+                                {
+                                  "type": "Identifier",
+                                  "name": "image",
+                                  "range": [
+                                    330,
+                                    335
+                                  ],
+                                  "loc": {
+                                    "start": {
+                                      "line": 19,
+                                      "column": 18
+                                    },
+                                    "end": {
+                                      "line": 19,
+                                      "column": 23
+                                    }
                                   }
                                 }
-                              },
+                              ],
                               "callee": {
                                 "type": "Identifier",
                                 "name": "figure",

--- a/tests/fixtures/parser/ast/svelte5/docs/snippets/02-output.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/snippets/02-output.json
@@ -534,253 +534,6 @@
           }
         }
       ],
-      "context": {
-        "type": "ObjectPattern",
-        "properties": [
-          {
-            "type": "Property",
-            "kind": "init",
-            "computed": false,
-            "key": {
-              "type": "Identifier",
-              "name": "src",
-              "range": [
-                19,
-                22
-              ],
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 19
-                },
-                "end": {
-                  "line": 1,
-                  "column": 22
-                }
-              }
-            },
-            "method": false,
-            "shorthand": true,
-            "value": {
-              "type": "Identifier",
-              "name": "src",
-              "range": [
-                19,
-                22
-              ],
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 19
-                },
-                "end": {
-                  "line": 1,
-                  "column": 22
-                }
-              }
-            },
-            "range": [
-              19,
-              22
-            ],
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 19
-              },
-              "end": {
-                "line": 1,
-                "column": 22
-              }
-            }
-          },
-          {
-            "type": "Property",
-            "kind": "init",
-            "computed": false,
-            "key": {
-              "type": "Identifier",
-              "name": "caption",
-              "range": [
-                24,
-                31
-              ],
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 24
-                },
-                "end": {
-                  "line": 1,
-                  "column": 31
-                }
-              }
-            },
-            "method": false,
-            "shorthand": true,
-            "value": {
-              "type": "Identifier",
-              "name": "caption",
-              "range": [
-                24,
-                31
-              ],
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 24
-                },
-                "end": {
-                  "line": 1,
-                  "column": 31
-                }
-              }
-            },
-            "range": [
-              24,
-              31
-            ],
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 24
-              },
-              "end": {
-                "line": 1,
-                "column": 31
-              }
-            }
-          },
-          {
-            "type": "Property",
-            "kind": "init",
-            "computed": false,
-            "key": {
-              "type": "Identifier",
-              "name": "width",
-              "range": [
-                33,
-                38
-              ],
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 33
-                },
-                "end": {
-                  "line": 1,
-                  "column": 38
-                }
-              }
-            },
-            "method": false,
-            "shorthand": true,
-            "value": {
-              "type": "Identifier",
-              "name": "width",
-              "range": [
-                33,
-                38
-              ],
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 33
-                },
-                "end": {
-                  "line": 1,
-                  "column": 38
-                }
-              }
-            },
-            "range": [
-              33,
-              38
-            ],
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 33
-              },
-              "end": {
-                "line": 1,
-                "column": 38
-              }
-            }
-          },
-          {
-            "type": "Property",
-            "kind": "init",
-            "computed": false,
-            "key": {
-              "type": "Identifier",
-              "name": "height",
-              "range": [
-                40,
-                46
-              ],
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 40
-                },
-                "end": {
-                  "line": 1,
-                  "column": 46
-                }
-              }
-            },
-            "method": false,
-            "shorthand": true,
-            "value": {
-              "type": "Identifier",
-              "name": "height",
-              "range": [
-                40,
-                46
-              ],
-              "loc": {
-                "start": {
-                  "line": 1,
-                  "column": 40
-                },
-                "end": {
-                  "line": 1,
-                  "column": 46
-                }
-              }
-            },
-            "range": [
-              40,
-              46
-            ],
-            "loc": {
-              "start": {
-                "line": 1,
-                "column": 40
-              },
-              "end": {
-                "line": 1,
-                "column": 46
-              }
-            }
-          }
-        ],
-        "range": [
-          17,
-          48
-        ],
-        "loc": {
-          "start": {
-            "line": 1,
-            "column": 17
-          },
-          "end": {
-            "line": 1,
-            "column": 48
-          }
-        }
-      },
       "id": {
         "type": "Identifier",
         "name": "figure",
@@ -799,6 +552,255 @@
           }
         }
       },
+      "params": [
+        {
+          "type": "ObjectPattern",
+          "properties": [
+            {
+              "type": "Property",
+              "kind": "init",
+              "computed": false,
+              "key": {
+                "type": "Identifier",
+                "name": "src",
+                "range": [
+                  19,
+                  22
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 19
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 22
+                  }
+                }
+              },
+              "method": false,
+              "shorthand": true,
+              "value": {
+                "type": "Identifier",
+                "name": "src",
+                "range": [
+                  19,
+                  22
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 19
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 22
+                  }
+                }
+              },
+              "range": [
+                19,
+                22
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 19
+                },
+                "end": {
+                  "line": 1,
+                  "column": 22
+                }
+              }
+            },
+            {
+              "type": "Property",
+              "kind": "init",
+              "computed": false,
+              "key": {
+                "type": "Identifier",
+                "name": "caption",
+                "range": [
+                  24,
+                  31
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 24
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 31
+                  }
+                }
+              },
+              "method": false,
+              "shorthand": true,
+              "value": {
+                "type": "Identifier",
+                "name": "caption",
+                "range": [
+                  24,
+                  31
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 24
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 31
+                  }
+                }
+              },
+              "range": [
+                24,
+                31
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 24
+                },
+                "end": {
+                  "line": 1,
+                  "column": 31
+                }
+              }
+            },
+            {
+              "type": "Property",
+              "kind": "init",
+              "computed": false,
+              "key": {
+                "type": "Identifier",
+                "name": "width",
+                "range": [
+                  33,
+                  38
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 33
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 38
+                  }
+                }
+              },
+              "method": false,
+              "shorthand": true,
+              "value": {
+                "type": "Identifier",
+                "name": "width",
+                "range": [
+                  33,
+                  38
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 33
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 38
+                  }
+                }
+              },
+              "range": [
+                33,
+                38
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 33
+                },
+                "end": {
+                  "line": 1,
+                  "column": 38
+                }
+              }
+            },
+            {
+              "type": "Property",
+              "kind": "init",
+              "computed": false,
+              "key": {
+                "type": "Identifier",
+                "name": "height",
+                "range": [
+                  40,
+                  46
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 40
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 46
+                  }
+                }
+              },
+              "method": false,
+              "shorthand": true,
+              "value": {
+                "type": "Identifier",
+                "name": "height",
+                "range": [
+                  40,
+                  46
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 40
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 46
+                  }
+                }
+              },
+              "range": [
+                40,
+                46
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 40
+                },
+                "end": {
+                  "line": 1,
+                  "column": 46
+                }
+              }
+            }
+          ],
+          "range": [
+            17,
+            48
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 17
+            },
+            "end": {
+              "line": 1,
+              "column": 48
+            }
+          }
+        }
+      ],
       "range": [
         0,
         166

--- a/tests/fixtures/parser/ast/svelte5/docs/snippets/03-snippet-scope-output.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/snippets/03-snippet-scope-output.json
@@ -576,25 +576,27 @@
     },
     {
       "type": "SvelteRenderTag",
-      "argument": {
-        "type": "Literal",
-        "raw": "'alice'",
-        "value": "alice",
-        "range": [
-          159,
-          166
-        ],
-        "loc": {
-          "start": {
-            "line": 9,
-            "column": 15
-          },
-          "end": {
-            "line": 9,
-            "column": 22
+      "arguments": [
+        {
+          "type": "Literal",
+          "raw": "'alice'",
+          "value": "alice",
+          "range": [
+            159,
+            166
+          ],
+          "loc": {
+            "start": {
+              "line": 9,
+              "column": 15
+            },
+            "end": {
+              "line": 9,
+              "column": 22
+            }
           }
         }
-      },
+      ],
       "callee": {
         "type": "Identifier",
         "name": "hello",
@@ -648,25 +650,27 @@
     },
     {
       "type": "SvelteRenderTag",
-      "argument": {
-        "type": "Literal",
-        "raw": "'bob'",
-        "value": "bob",
-        "range": [
-          184,
-          189
-        ],
-        "loc": {
-          "start": {
-            "line": 10,
-            "column": 15
-          },
-          "end": {
-            "line": 10,
-            "column": 20
+      "arguments": [
+        {
+          "type": "Literal",
+          "raw": "'bob'",
+          "value": "bob",
+          "range": [
+            184,
+            189
+          ],
+          "loc": {
+            "start": {
+              "line": 10,
+              "column": 15
+            },
+            "end": {
+              "line": 10,
+              "column": 20
+            }
           }
         }
-      },
+      ],
       "callee": {
         "type": "Identifier",
         "name": "hello",

--- a/tests/fixtures/parser/ast/svelte5/docs/snippets/03-snippet-scope-output.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/snippets/03-snippet-scope-output.json
@@ -505,24 +505,6 @@
           }
         }
       ],
-      "context": {
-        "type": "Identifier",
-        "name": "name",
-        "range": [
-          92,
-          96
-        ],
-        "loc": {
-          "start": {
-            "line": 5,
-            "column": 16
-          },
-          "end": {
-            "line": 5,
-            "column": 20
-          }
-        }
-      },
       "id": {
         "type": "Identifier",
         "name": "hello",
@@ -541,6 +523,26 @@
           }
         }
       },
+      "params": [
+        {
+          "type": "Identifier",
+          "name": "name",
+          "range": [
+            92,
+            96
+          ],
+          "loc": {
+            "start": {
+              "line": 5,
+              "column": 16
+            },
+            "end": {
+              "line": 5,
+              "column": 20
+            }
+          }
+        }
+      ],
       "range": [
         76,
         142

--- a/tests/fixtures/parser/ast/svelte5/docs/snippets/04-snippet-scope-output.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/snippets/04-snippet-scope-output.json
@@ -85,7 +85,6 @@
                   }
                 }
               ],
-              "context": null,
               "id": {
                 "type": "Identifier",
                 "name": "y",
@@ -104,6 +103,7 @@
                   }
                 }
               },
+              "params": [],
               "range": [
                 24,
                 51
@@ -210,7 +210,6 @@
               }
             }
           ],
-          "context": null,
           "id": {
             "type": "Identifier",
             "name": "x",
@@ -229,6 +228,7 @@
               }
             }
           },
+          "params": [],
           "range": [
             7,
             104

--- a/tests/fixtures/parser/ast/svelte5/docs/snippets/04-snippet-scope-output.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/snippets/04-snippet-scope-output.json
@@ -175,7 +175,7 @@
             },
             {
               "type": "SvelteRenderTag",
-              "argument": null,
+              "arguments": [],
               "callee": {
                 "type": "Identifier",
                 "name": "y",
@@ -300,7 +300,7 @@
         },
         {
           "type": "SvelteRenderTag",
-          "argument": null,
+          "arguments": [],
           "callee": {
             "type": "Identifier",
             "name": "y",
@@ -441,7 +441,7 @@
     },
     {
       "type": "SvelteRenderTag",
-      "argument": null,
+      "arguments": [],
       "callee": {
         "type": "Identifier",
         "name": "x",

--- a/tests/fixtures/parser/ast/svelte5/docs/snippets/05-snippet-scope-output.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/snippets/05-snippet-scope-output.json
@@ -359,14 +359,50 @@
             },
             {
               "type": "SvelteRenderTag",
-              "argument": {
-                "type": "BinaryExpression",
-                "left": {
-                  "type": "Identifier",
-                  "name": "n",
+              "arguments": [
+                {
+                  "type": "BinaryExpression",
+                  "left": {
+                    "type": "Identifier",
+                    "name": "n",
+                    "range": [
+                      131,
+                      132
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 8,
+                        "column": 21
+                      },
+                      "end": {
+                        "line": 8,
+                        "column": 22
+                      }
+                    }
+                  },
+                  "operator": "-",
+                  "right": {
+                    "type": "Literal",
+                    "raw": "1",
+                    "value": 1,
+                    "range": [
+                      135,
+                      136
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 8,
+                        "column": 25
+                      },
+                      "end": {
+                        "line": 8,
+                        "column": 26
+                      }
+                    }
+                  },
                   "range": [
                     131,
-                    132
+                    136
                   ],
                   "loc": {
                     "start": {
@@ -375,45 +411,11 @@
                     },
                     "end": {
                       "line": 8,
-                      "column": 22
-                    }
-                  }
-                },
-                "operator": "-",
-                "right": {
-                  "type": "Literal",
-                  "raw": "1",
-                  "value": 1,
-                  "range": [
-                    135,
-                    136
-                  ],
-                  "loc": {
-                    "start": {
-                      "line": 8,
-                      "column": 25
-                    },
-                    "end": {
-                      "line": 8,
                       "column": 26
                     }
                   }
-                },
-                "range": [
-                  131,
-                  136
-                ],
-                "loc": {
-                  "start": {
-                    "line": 8,
-                    "column": 21
-                  },
-                  "end": {
-                    "line": 8,
-                    "column": 26
-                  }
                 }
-              },
+              ],
               "callee": {
                 "type": "Identifier",
                 "name": "countdown",
@@ -454,7 +456,7 @@
             "children": [
               {
                 "type": "SvelteRenderTag",
-                "argument": null,
+                "arguments": [],
                 "callee": {
                   "type": "Identifier",
                   "name": "blastoff",
@@ -591,25 +593,27 @@
     },
     {
       "type": "SvelteRenderTag",
-      "argument": {
-        "type": "Literal",
-        "raw": "10",
-        "value": 10,
-        "range": [
-          209,
-          211
-        ],
-        "loc": {
-          "start": {
-            "line": 14,
-            "column": 19
-          },
-          "end": {
-            "line": 14,
-            "column": 21
+      "arguments": [
+        {
+          "type": "Literal",
+          "raw": "10",
+          "value": 10,
+          "range": [
+            209,
+            211
+          ],
+          "loc": {
+            "start": {
+              "line": 14,
+              "column": 19
+            },
+            "end": {
+              "line": 14,
+              "column": 21
+            }
           }
         }
-      },
+      ],
       "callee": {
         "type": "Identifier",
         "name": "countdown",

--- a/tests/fixtures/parser/ast/svelte5/docs/snippets/05-snippet-scope-output.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/snippets/05-snippet-scope-output.json
@@ -97,7 +97,6 @@
           }
         }
       ],
-      "context": null,
       "id": {
         "type": "Identifier",
         "name": "blastoff",
@@ -116,6 +115,7 @@
           }
         }
       },
+      "params": [],
       "range": [
         0,
         49
@@ -522,24 +522,6 @@
           }
         }
       ],
-      "context": {
-        "type": "Identifier",
-        "name": "n",
-        "range": [
-          71,
-          72
-        ],
-        "loc": {
-          "start": {
-            "line": 5,
-            "column": 20
-          },
-          "end": {
-            "line": 5,
-            "column": 21
-          }
-        }
-      },
       "id": {
         "type": "Identifier",
         "name": "countdown",
@@ -558,6 +540,26 @@
           }
         }
       },
+      "params": [
+        {
+          "type": "Identifier",
+          "name": "n",
+          "range": [
+            71,
+            72
+          ],
+          "loc": {
+            "start": {
+              "line": 5,
+              "column": 20
+            },
+            "end": {
+              "line": 5,
+              "column": 21
+            }
+          }
+        }
+      ],
       "range": [
         51,
         188

--- a/tests/fixtures/parser/ast/svelte5/docs/snippets/06-passing-snippets-to-components-output.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/snippets/06-passing-snippets-to-components-output.json
@@ -1244,7 +1244,6 @@
           }
         }
       ],
-      "context": null,
       "id": {
         "type": "Identifier",
         "name": "header",
@@ -1263,6 +1262,7 @@
           }
         }
       },
+      "params": [],
       "range": [
         206,
         298
@@ -2015,24 +2015,6 @@
           }
         }
       ],
-      "context": {
-        "type": "Identifier",
-        "name": "d",
-        "range": [
-          314,
-          315
-        ],
-        "loc": {
-          "start": {
-            "line": 18,
-            "column": 14
-          },
-          "end": {
-            "line": 18,
-            "column": 15
-          }
-        }
-      },
       "id": {
         "type": "Identifier",
         "name": "row",
@@ -2051,6 +2033,26 @@
           }
         }
       },
+      "params": [
+        {
+          "type": "Identifier",
+          "name": "d",
+          "range": [
+            314,
+            315
+          ],
+          "loc": {
+            "start": {
+              "line": 18,
+              "column": 14
+            },
+            "end": {
+              "line": 18,
+              "column": 15
+            }
+          }
+        }
+      ],
       "range": [
         300,
         413

--- a/tests/fixtures/parser/ast/svelte5/docs/snippets/07-passing-snippets-to-components-output.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/snippets/07-passing-snippets-to-components-output.json
@@ -597,7 +597,6 @@
               }
             }
           ],
-          "context": null,
           "id": {
             "type": "Identifier",
             "name": "header",
@@ -616,6 +615,7 @@
               }
             }
           },
+          "params": [],
           "range": [
             75,
             172
@@ -1368,24 +1368,6 @@
               }
             }
           ],
-          "context": {
-            "type": "Identifier",
-            "name": "d",
-            "range": [
-              189,
-              190
-            ],
-            "loc": {
-              "start": {
-                "line": 10,
-                "column": 15
-              },
-              "end": {
-                "line": 10,
-                "column": 16
-              }
-            }
-          },
           "id": {
             "type": "Identifier",
             "name": "row",
@@ -1404,6 +1386,26 @@
               }
             }
           },
+          "params": [
+            {
+              "type": "Identifier",
+              "name": "d",
+              "range": [
+                189,
+                190
+              ],
+              "loc": {
+                "start": {
+                  "line": 10,
+                  "column": 15
+                },
+                "end": {
+                  "line": 10,
+                  "column": 16
+                }
+              }
+            }
+          ],
           "range": [
             175,
             293

--- a/tests/fixtures/parser/ast/svelte5/docs/snippets/09-passing-snippets-to-components-output.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/snippets/09-passing-snippets-to-components-output.json
@@ -539,7 +539,7 @@
                   "children": [
                     {
                       "type": "SvelteRenderTag",
-                      "argument": null,
+                      "arguments": [],
                       "callee": {
                         "type": "Identifier",
                         "name": "children",

--- a/tests/fixtures/parser/ast/svelte5/render01-input.svelte
+++ b/tests/fixtures/parser/ast/svelte5/render01-input.svelte
@@ -1,0 +1,9 @@
+<script>
+	const { foo } = $props();
+
+	function bar() {
+		return "baz";
+	}
+</script>
+
+{@render foo(bar())}

--- a/tests/fixtures/parser/ast/svelte5/render01-output.json
+++ b/tests/fixtures/parser/ast/svelte5/render01-output.json
@@ -1,0 +1,1062 @@
+{
+  "type": "Program",
+  "body": [
+    {
+      "type": "SvelteScriptElement",
+      "name": {
+        "type": "SvelteName",
+        "name": "script",
+        "range": [
+          1,
+          7
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 7
+          }
+        }
+      },
+      "startTag": {
+        "type": "SvelteStartTag",
+        "attributes": [],
+        "selfClosing": false,
+        "range": [
+          0,
+          8
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 8
+          }
+        }
+      },
+      "body": [
+        {
+          "type": "VariableDeclaration",
+          "kind": "const",
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "id": {
+                "type": "ObjectPattern",
+                "properties": [
+                  {
+                    "type": "Property",
+                    "kind": "init",
+                    "computed": false,
+                    "key": {
+                      "type": "Identifier",
+                      "name": "foo",
+                      "range": [
+                        18,
+                        21
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 12
+                        }
+                      }
+                    },
+                    "method": false,
+                    "shorthand": true,
+                    "value": {
+                      "type": "Identifier",
+                      "name": "foo",
+                      "range": [
+                        18,
+                        21
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 12
+                        }
+                      }
+                    },
+                    "range": [
+                      18,
+                      21
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 9
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 12
+                      }
+                    }
+                  }
+                ],
+                "range": [
+                  16,
+                  23
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 14
+                  }
+                }
+              },
+              "init": {
+                "type": "CallExpression",
+                "arguments": [],
+                "callee": {
+                  "type": "Identifier",
+                  "name": "$props",
+                  "range": [
+                    26,
+                    32
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 17
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 23
+                    }
+                  }
+                },
+                "optional": false,
+                "range": [
+                  26,
+                  34
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 17
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 25
+                  }
+                }
+              },
+              "range": [
+                16,
+                34
+              ],
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 7
+                },
+                "end": {
+                  "line": 2,
+                  "column": 25
+                }
+              }
+            }
+          ],
+          "range": [
+            10,
+            35
+          ],
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 1
+            },
+            "end": {
+              "line": 2,
+              "column": 26
+            }
+          }
+        },
+        {
+          "type": "FunctionDeclaration",
+          "async": false,
+          "body": {
+            "type": "BlockStatement",
+            "body": [
+              {
+                "type": "ReturnStatement",
+                "argument": {
+                  "type": "Literal",
+                  "raw": "\"baz\"",
+                  "value": "baz",
+                  "range": [
+                    64,
+                    69
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 14
+                    }
+                  }
+                },
+                "range": [
+                  57,
+                  70
+                ],
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 15
+                  }
+                }
+              }
+            ],
+            "range": [
+              53,
+              73
+            ],
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 16
+              },
+              "end": {
+                "line": 6,
+                "column": 2
+              }
+            }
+          },
+          "expression": false,
+          "generator": false,
+          "id": {
+            "type": "Identifier",
+            "name": "bar",
+            "range": [
+              47,
+              50
+            ],
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 10
+              },
+              "end": {
+                "line": 4,
+                "column": 13
+              }
+            }
+          },
+          "params": [],
+          "range": [
+            38,
+            73
+          ],
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 1
+            },
+            "end": {
+              "line": 6,
+              "column": 2
+            }
+          }
+        }
+      ],
+      "endTag": {
+        "type": "SvelteEndTag",
+        "range": [
+          74,
+          83
+        ],
+        "loc": {
+          "start": {
+            "line": 7,
+            "column": 0
+          },
+          "end": {
+            "line": 7,
+            "column": 9
+          }
+        }
+      },
+      "range": [
+        0,
+        83
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 7,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": "SvelteText",
+      "value": "\n\n",
+      "range": [
+        83,
+        85
+      ],
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 9
+        },
+        "end": {
+          "line": 9,
+          "column": 0
+        }
+      }
+    },
+    {
+      "type": "SvelteRenderTag",
+      "arguments": [
+        {
+          "type": "CallExpression",
+          "arguments": [],
+          "callee": {
+            "type": "Identifier",
+            "name": "bar",
+            "range": [
+              98,
+              101
+            ],
+            "loc": {
+              "start": {
+                "line": 9,
+                "column": 13
+              },
+              "end": {
+                "line": 9,
+                "column": 16
+              }
+            }
+          },
+          "optional": false,
+          "range": [
+            98,
+            103
+          ],
+          "loc": {
+            "start": {
+              "line": 9,
+              "column": 13
+            },
+            "end": {
+              "line": 9,
+              "column": 18
+            }
+          }
+        }
+      ],
+      "callee": {
+        "type": "Identifier",
+        "name": "foo",
+        "range": [
+          94,
+          97
+        ],
+        "loc": {
+          "start": {
+            "line": 9,
+            "column": 9
+          },
+          "end": {
+            "line": 9,
+            "column": 12
+          }
+        }
+      },
+      "range": [
+        85,
+        105
+      ],
+      "loc": {
+        "start": {
+          "line": 9,
+          "column": 0
+        },
+        "end": {
+          "line": 9,
+          "column": 20
+        }
+      }
+    }
+  ],
+  "sourceType": "module",
+  "comments": [],
+  "tokens": [
+    {
+      "type": "Punctuator",
+      "value": "<",
+      "range": [
+        0,
+        1
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "script",
+      "range": [
+        1,
+        7
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 1,
+          "column": 7
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ">",
+      "range": [
+        7,
+        8
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 7
+        },
+        "end": {
+          "line": 1,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": "Keyword",
+      "value": "const",
+      "range": [
+        10,
+        15
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 1
+        },
+        "end": {
+          "line": 2,
+          "column": 6
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        16,
+        17
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 7
+        },
+        "end": {
+          "line": 2,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "foo",
+      "range": [
+        18,
+        21
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 9
+        },
+        "end": {
+          "line": 2,
+          "column": 12
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        22,
+        23
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 13
+        },
+        "end": {
+          "line": 2,
+          "column": 14
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "=",
+      "range": [
+        24,
+        25
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 15
+        },
+        "end": {
+          "line": 2,
+          "column": 16
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "$props",
+      "range": [
+        26,
+        32
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 17
+        },
+        "end": {
+          "line": 2,
+          "column": 23
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "(",
+      "range": [
+        32,
+        33
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 23
+        },
+        "end": {
+          "line": 2,
+          "column": 24
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ")",
+      "range": [
+        33,
+        34
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 24
+        },
+        "end": {
+          "line": 2,
+          "column": 25
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ";",
+      "range": [
+        34,
+        35
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 25
+        },
+        "end": {
+          "line": 2,
+          "column": 26
+        }
+      }
+    },
+    {
+      "type": "Keyword",
+      "value": "function",
+      "range": [
+        38,
+        46
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 1
+        },
+        "end": {
+          "line": 4,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "bar",
+      "range": [
+        47,
+        50
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 10
+        },
+        "end": {
+          "line": 4,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "(",
+      "range": [
+        50,
+        51
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 13
+        },
+        "end": {
+          "line": 4,
+          "column": 14
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ")",
+      "range": [
+        51,
+        52
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 14
+        },
+        "end": {
+          "line": 4,
+          "column": 15
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        53,
+        54
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 16
+        },
+        "end": {
+          "line": 4,
+          "column": 17
+        }
+      }
+    },
+    {
+      "type": "Keyword",
+      "value": "return",
+      "range": [
+        57,
+        63
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 2
+        },
+        "end": {
+          "line": 5,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": "String",
+      "value": "\"baz\"",
+      "range": [
+        64,
+        69
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 9
+        },
+        "end": {
+          "line": 5,
+          "column": 14
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ";",
+      "range": [
+        69,
+        70
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 14
+        },
+        "end": {
+          "line": 5,
+          "column": 15
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        72,
+        73
+      ],
+      "loc": {
+        "start": {
+          "line": 6,
+          "column": 1
+        },
+        "end": {
+          "line": 6,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "<",
+      "range": [
+        74,
+        75
+      ],
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 0
+        },
+        "end": {
+          "line": 7,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "/",
+      "range": [
+        75,
+        76
+      ],
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 1
+        },
+        "end": {
+          "line": 7,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "script",
+      "range": [
+        76,
+        82
+      ],
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 2
+        },
+        "end": {
+          "line": 7,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ">",
+      "range": [
+        82,
+        83
+      ],
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 8
+        },
+        "end": {
+          "line": 7,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": "HTMLText",
+      "value": "\n\n",
+      "range": [
+        83,
+        85
+      ],
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 9
+        },
+        "end": {
+          "line": 9,
+          "column": 0
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        85,
+        86
+      ],
+      "loc": {
+        "start": {
+          "line": 9,
+          "column": 0
+        },
+        "end": {
+          "line": 9,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "MustacheKeyword",
+      "value": "@render",
+      "range": [
+        86,
+        93
+      ],
+      "loc": {
+        "start": {
+          "line": 9,
+          "column": 1
+        },
+        "end": {
+          "line": 9,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "foo",
+      "range": [
+        94,
+        97
+      ],
+      "loc": {
+        "start": {
+          "line": 9,
+          "column": 9
+        },
+        "end": {
+          "line": 9,
+          "column": 12
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "(",
+      "range": [
+        97,
+        98
+      ],
+      "loc": {
+        "start": {
+          "line": 9,
+          "column": 12
+        },
+        "end": {
+          "line": 9,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "bar",
+      "range": [
+        98,
+        101
+      ],
+      "loc": {
+        "start": {
+          "line": 9,
+          "column": 13
+        },
+        "end": {
+          "line": 9,
+          "column": 16
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "(",
+      "range": [
+        101,
+        102
+      ],
+      "loc": {
+        "start": {
+          "line": 9,
+          "column": 16
+        },
+        "end": {
+          "line": 9,
+          "column": 17
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ")",
+      "range": [
+        102,
+        103
+      ],
+      "loc": {
+        "start": {
+          "line": 9,
+          "column": 17
+        },
+        "end": {
+          "line": 9,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ")",
+      "range": [
+        103,
+        104
+      ],
+      "loc": {
+        "start": {
+          "line": 9,
+          "column": 18
+        },
+        "end": {
+          "line": 9,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        104,
+        105
+      ],
+      "loc": {
+        "start": {
+          "line": 9,
+          "column": 19
+        },
+        "end": {
+          "line": 9,
+          "column": 20
+        }
+      }
+    }
+  ],
+  "range": [
+    0,
+    106
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 10,
+      "column": 0
+    }
+  }
+}

--- a/tests/fixtures/parser/ast/svelte5/render01-scope-output.json
+++ b/tests/fixtures/parser/ast/svelte5/render01-scope-output.json
@@ -1,0 +1,712 @@
+{
+  "type": "global",
+  "variables": [
+    {
+      "name": "$$slots",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$props",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$restProps",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$state",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$derived",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$effect",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$props",
+      "identifiers": [],
+      "defs": [],
+      "references": [
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "$props",
+            "range": [
+              26,
+              32
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 17
+              },
+              "end": {
+                "line": 2,
+                "column": 23
+              }
+            }
+          },
+          "from": "module",
+          "init": null,
+          "resolved": null
+        }
+      ]
+    },
+    {
+      "name": "$inspect",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    }
+  ],
+  "references": [],
+  "childScopes": [
+    {
+      "type": "module",
+      "variables": [
+        {
+          "name": "foo",
+          "identifiers": [
+            {
+              "type": "Identifier",
+              "name": "foo",
+              "range": [
+                18,
+                21
+              ],
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 9
+                },
+                "end": {
+                  "line": 2,
+                  "column": 12
+                }
+              }
+            }
+          ],
+          "defs": [
+            {
+              "type": "Variable",
+              "name": {
+                "type": "Identifier",
+                "name": "foo",
+                "range": [
+                  18,
+                  21
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 12
+                  }
+                }
+              },
+              "node": {
+                "type": "VariableDeclarator",
+                "id": {
+                  "type": "ObjectPattern",
+                  "properties": [
+                    {
+                      "type": "Property",
+                      "kind": "init",
+                      "computed": false,
+                      "key": {
+                        "type": "Identifier",
+                        "name": "foo",
+                        "range": [
+                          18,
+                          21
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 9
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 12
+                          }
+                        }
+                      },
+                      "method": false,
+                      "shorthand": true,
+                      "value": {
+                        "type": "Identifier",
+                        "name": "foo",
+                        "range": [
+                          18,
+                          21
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 2,
+                            "column": 9
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 12
+                          }
+                        }
+                      },
+                      "range": [
+                        18,
+                        21
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 12
+                        }
+                      }
+                    }
+                  ],
+                  "range": [
+                    16,
+                    23
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 14
+                    }
+                  }
+                },
+                "init": {
+                  "type": "CallExpression",
+                  "arguments": [],
+                  "callee": {
+                    "type": "Identifier",
+                    "name": "$props",
+                    "range": [
+                      26,
+                      32
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 17
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 23
+                      }
+                    }
+                  },
+                  "optional": false,
+                  "range": [
+                    26,
+                    34
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 17
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 25
+                    }
+                  }
+                },
+                "range": [
+                  16,
+                  34
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 25
+                  }
+                }
+              }
+            }
+          ],
+          "references": [
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "foo",
+                "range": [
+                  18,
+                  21
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 12
+                  }
+                }
+              },
+              "from": "module",
+              "init": true,
+              "resolved": {
+                "type": "Identifier",
+                "name": "foo",
+                "range": [
+                  18,
+                  21
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 12
+                  }
+                }
+              }
+            },
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "foo",
+                "range": [
+                  94,
+                  97
+                ],
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 12
+                  }
+                }
+              },
+              "from": "module",
+              "init": null,
+              "resolved": {
+                "type": "Identifier",
+                "name": "foo",
+                "range": [
+                  18,
+                  21
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 12
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "name": "bar",
+          "identifiers": [
+            {
+              "type": "Identifier",
+              "name": "bar",
+              "range": [
+                47,
+                50
+              ],
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 10
+                },
+                "end": {
+                  "line": 4,
+                  "column": 13
+                }
+              }
+            }
+          ],
+          "defs": [
+            {
+              "type": "FunctionName",
+              "name": {
+                "type": "Identifier",
+                "name": "bar",
+                "range": [
+                  47,
+                  50
+                ],
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 13
+                  }
+                }
+              },
+              "node": {
+                "type": "FunctionDeclaration",
+                "async": false,
+                "body": {
+                  "type": "BlockStatement",
+                  "body": [
+                    {
+                      "type": "ReturnStatement",
+                      "argument": {
+                        "type": "Literal",
+                        "raw": "\"baz\"",
+                        "value": "baz",
+                        "range": [
+                          64,
+                          69
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 5,
+                            "column": 9
+                          },
+                          "end": {
+                            "line": 5,
+                            "column": 14
+                          }
+                        }
+                      },
+                      "range": [
+                        57,
+                        70
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 5,
+                          "column": 2
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 15
+                        }
+                      }
+                    }
+                  ],
+                  "range": [
+                    53,
+                    73
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 16
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 2
+                    }
+                  }
+                },
+                "expression": false,
+                "generator": false,
+                "id": {
+                  "type": "Identifier",
+                  "name": "bar",
+                  "range": [
+                    47,
+                    50
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 10
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 13
+                    }
+                  }
+                },
+                "params": [],
+                "range": [
+                  38,
+                  73
+                ],
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 2
+                  }
+                }
+              }
+            }
+          ],
+          "references": [
+            {
+              "identifier": {
+                "type": "Identifier",
+                "name": "bar",
+                "range": [
+                  98,
+                  101
+                ],
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 13
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 16
+                  }
+                }
+              },
+              "from": "module",
+              "init": null,
+              "resolved": {
+                "type": "Identifier",
+                "name": "bar",
+                "range": [
+                  47,
+                  50
+                ],
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 13
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "references": [
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "foo",
+            "range": [
+              18,
+              21
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 9
+              },
+              "end": {
+                "line": 2,
+                "column": 12
+              }
+            }
+          },
+          "from": "module",
+          "init": true,
+          "resolved": {
+            "type": "Identifier",
+            "name": "foo",
+            "range": [
+              18,
+              21
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 9
+              },
+              "end": {
+                "line": 2,
+                "column": 12
+              }
+            }
+          }
+        },
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "$props",
+            "range": [
+              26,
+              32
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 17
+              },
+              "end": {
+                "line": 2,
+                "column": 23
+              }
+            }
+          },
+          "from": "module",
+          "init": null,
+          "resolved": null
+        },
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "foo",
+            "range": [
+              94,
+              97
+            ],
+            "loc": {
+              "start": {
+                "line": 9,
+                "column": 9
+              },
+              "end": {
+                "line": 9,
+                "column": 12
+              }
+            }
+          },
+          "from": "module",
+          "init": null,
+          "resolved": {
+            "type": "Identifier",
+            "name": "foo",
+            "range": [
+              18,
+              21
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 9
+              },
+              "end": {
+                "line": 2,
+                "column": 12
+              }
+            }
+          }
+        },
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "bar",
+            "range": [
+              98,
+              101
+            ],
+            "loc": {
+              "start": {
+                "line": 9,
+                "column": 13
+              },
+              "end": {
+                "line": 9,
+                "column": 16
+              }
+            }
+          },
+          "from": "module",
+          "init": null,
+          "resolved": {
+            "type": "Identifier",
+            "name": "bar",
+            "range": [
+              47,
+              50
+            ],
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 10
+              },
+              "end": {
+                "line": 4,
+                "column": 13
+              }
+            }
+          }
+        }
+      ],
+      "childScopes": [
+        {
+          "type": "function",
+          "variables": [
+            {
+              "name": "arguments",
+              "identifiers": [],
+              "defs": [],
+              "references": []
+            }
+          ],
+          "references": [],
+          "childScopes": [],
+          "through": []
+        }
+      ],
+      "through": [
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "$props",
+            "range": [
+              26,
+              32
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 17
+              },
+              "end": {
+                "line": 2,
+                "column": 23
+              }
+            }
+          },
+          "from": "module",
+          "init": null,
+          "resolved": null
+        }
+      ]
+    }
+  ],
+  "through": []
+}

--- a/tests/fixtures/parser/ast/svelte5/ts-snippet01-output.json
+++ b/tests/fixtures/parser/ast/svelte5/ts-snippet01-output.json
@@ -337,58 +337,6 @@
           }
         }
       ],
-      "context": {
-        "type": "Identifier",
-        "name": "msg",
-        "typeAnnotation": {
-          "type": "TSTypeAnnotation",
-          "typeAnnotation": {
-            "type": "TSStringKeyword",
-            "range": [
-              66,
-              72
-            ],
-            "loc": {
-              "start": {
-                "line": 5,
-                "column": 19
-              },
-              "end": {
-                "line": 5,
-                "column": 25
-              }
-            }
-          },
-          "range": [
-            64,
-            72
-          ],
-          "loc": {
-            "start": {
-              "line": 5,
-              "column": 17
-            },
-            "end": {
-              "line": 5,
-              "column": 25
-            }
-          }
-        },
-        "range": [
-          61,
-          72
-        ],
-        "loc": {
-          "start": {
-            "line": 5,
-            "column": 14
-          },
-          "end": {
-            "line": 5,
-            "column": 25
-          }
-        }
-      },
       "id": {
         "type": "Identifier",
         "name": "foo",
@@ -407,6 +355,60 @@
           }
         }
       },
+      "params": [
+        {
+          "type": "Identifier",
+          "name": "msg",
+          "typeAnnotation": {
+            "type": "TSTypeAnnotation",
+            "typeAnnotation": {
+              "type": "TSStringKeyword",
+              "range": [
+                66,
+                72
+              ],
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 19
+                },
+                "end": {
+                  "line": 5,
+                  "column": 25
+                }
+              }
+            },
+            "range": [
+              64,
+              72
+            ],
+            "loc": {
+              "start": {
+                "line": 5,
+                "column": 17
+              },
+              "end": {
+                "line": 5,
+                "column": 25
+              }
+            }
+          },
+          "range": [
+            61,
+            72
+          ],
+          "loc": {
+            "start": {
+              "line": 5,
+              "column": 14
+            },
+            "end": {
+              "line": 5,
+              "column": 25
+            }
+          }
+        }
+      ],
       "range": [
         47,
         99

--- a/tests/fixtures/parser/ast/svelte5/ts-snippet01-output.json
+++ b/tests/fixtures/parser/ast/svelte5/ts-snippet01-output.json
@@ -442,24 +442,26 @@
     },
     {
       "type": "SvelteRenderTag",
-      "argument": {
-        "type": "Identifier",
-        "name": "msg",
-        "range": [
-          114,
-          117
-        ],
-        "loc": {
-          "start": {
-            "line": 9,
-            "column": 13
-          },
-          "end": {
-            "line": 9,
-            "column": 16
+      "arguments": [
+        {
+          "type": "Identifier",
+          "name": "msg",
+          "range": [
+            114,
+            117
+          ],
+          "loc": {
+            "start": {
+              "line": 9,
+              "column": 13
+            },
+            "end": {
+              "line": 9,
+              "column": 16
+            }
           }
         }
-      },
+      ],
       "callee": {
         "type": "Identifier",
         "name": "foo",

--- a/tests/fixtures/parser/ast/svelte5/ts-snippet01-type-output.svelte
+++ b/tests/fixtures/parser/ast/svelte5/ts-snippet01-type-output.svelte
@@ -6,4 +6,4 @@
 	<p>{msg}</p> <!-- msg: string -->
 {/snippet}
 
-{@render foo(msg)} <!-- foo: (msg: string) => void, msg: string -->
+{@render foo(msg)} <!-- foo: (msg: string) => void -->

--- a/tests/fixtures/parser/ast/svelte5/ts-snippet01-type-output.svelte
+++ b/tests/fixtures/parser/ast/svelte5/ts-snippet01-type-output.svelte
@@ -6,4 +6,4 @@
 	<p>{msg}</p> <!-- msg: string -->
 {/snippet}
 
-{@render foo(msg)} <!-- foo: (msg: string) => void -->
+{@render foo(msg)} <!-- foo: (msg: string) => void, msg: string -->


### PR DESCRIPTION
related to https://github.com/sveltejs/eslint-plugin-svelte/issues/686