### PR TITLE
fix: set `svelteFeatures.runes` to `true` by default for Svelte 5

### DIFF
--- a/.changeset/brave-penguins-compete.md
+++ b/.changeset/brave-penguins-compete.md
@@ -1,0 +1,5 @@
+---
+"svelte-eslint-parser": patch
+---
+
+fix: Set `svelteFeatures.runes` to `true` by default for Svelte 5

--- a/README.md
+++ b/README.md
@@ -286,10 +286,11 @@ export default [
         svelteFeatures: {
           /* -- Experimental Svelte Features -- */
           /* It may be changed or removed in minor versions without notice. */
-          // If true, it will analyze Runes.
-          // By default, it will try to read `compilerOptions.runes` from `svelte.config.js`.
-          // However, note that if `parserOptions.svelteConfig` is not specified and the file cannot be parsed by static analysis, it will behave as `false`.
-          runes: false,
+          // This option is for Svelte 5. The default value is `true`.
+          // If `false`, ESLint will not recognize rune symbols.
+          // If not configured this option, The parser will try to read the option from `compilerOptions.runes` from `svelte.config.js`.
+          // If `parserOptions.svelteConfig` is not specified and the file cannot be parsed by static analysis, it will behave as `true`.
+          runes: true,
           /* -- Experimental Svelte Features -- */
           /* It may be changed or removed in minor versions without notice. */
           // Whether to parse the `generics` attribute.
@@ -311,10 +312,11 @@ For example in `.eslintrc.*`:
     "svelteFeatures": {
       /* -- Experimental Svelte Features -- */
       /* It may be changed or removed in minor versions without notice. */
-      // If true, it will analyze Runes.
-      // By default, it will try to read `compilerOptions.runes` from `svelte.config.js`.
-      // However, note that if the file cannot be parsed by static analysis, it will behave as false.
-      "runes": false,
+      // This option is for Svelte 5. The default value is `true`.
+      // If `false`, ESLint will not recognize rune symbols.
+      // If not configured this option, The parser will try to read the option from `compilerOptions.runes` from `svelte.config.js`.
+      // If `parserOptions.svelteConfig` is not specified and the file cannot be parsed by static analysis, it will behave as `true`.
+      "runes": true,
       /* -- Experimental Svelte Features -- */
       /* It may be changed or removed in minor versions without notice. */
       // Whether to parse the `generics` attribute.
@@ -329,7 +331,8 @@ For example in `.eslintrc.*`:
 
 **_This is an experimental feature. It may be changed or removed in minor versions without notice._**
 
-If you install Svelte v5 and turn on runes (`compilerOptions.runes` in `svelte.config.js` or `parserOptions.svelteFeatures.runes` in ESLint config is `true`), the parser will be able to parse runes, and will also be able to parse `*.js` and `*.ts` files.
+If you install Svelte v5 the parser will be able to parse runes, and will also be able to parse `*.js` and `*.ts` files.
+If you don't want to use Runes, you may need to configure. Please read [parserOptions.svelteFeatures](#parseroptionssveltefeatures) for more details.
 
 When using this mode in an ESLint configuration, it is recommended to set it per file pattern as below.
 
@@ -383,7 +386,6 @@ For example in `.eslintrc.*`:
       "parser": "svelte-eslint-parser",
       "parserOptions": {
         "parser": "...",
-        "svelteFeatures": { "runes": true },
         /* ... */
       },
     },
@@ -391,7 +393,6 @@ For example in `.eslintrc.*`:
       "files": ["*.svelte.js"],
       "parser": "svelte-eslint-parser",
       "parserOptions": {
-        "svelteFeatures": { "runes": true },
         /* ... */
       },
     },
@@ -400,7 +401,6 @@ For example in `.eslintrc.*`:
       "parser": "svelte-eslint-parser",
       "parserOptions": {
         "parser": "...(ts parser)...",
-        "svelteFeatures": { "runes": true },
         /* ... */
       },
     },

--- a/src/parser/parser-options.ts
+++ b/src/parser/parser-options.ts
@@ -20,11 +20,12 @@ export type NormalizedParserOptions = {
     [key: string]: any;
   };
   svelteFeatures?: {
-    // If true, it will analyze Runes.
-    // By default, it will try to read `compilerOptions.runes` from `svelte.config.js`.
-    // However, note that if it cannot be resolved due to static analysis, it will behave as false.
-    runes?: boolean;
     /* -- Experimental Svelte Features -- */
+    // This option is for Svelte 5. The default value is `true`.
+    // If `false`, ESLint will not recognize rune symbols.
+    // If not configured this option, The parser will try to read the option from `compilerOptions.runes` from `svelte.config.js`.
+    // If `parserOptions.svelteConfig` is not specified and the file cannot be parsed by static analysis, it will behave as `true`.
+    runes?: boolean;
     // Whether to parse the `generics` attribute.
     // See https://github.com/sveltejs/rfcs/pull/38
     experimentalGenerics?: boolean;

--- a/src/parser/svelte-parse-context.ts
+++ b/src/parser/svelte-parse-context.ts
@@ -25,7 +25,8 @@ export function isEnableRunes(
   if (!svelteVersion.gte(5)) return false;
   if (parserOptions.svelteFeatures?.runes != null) {
     return Boolean(parserOptions.svelteFeatures.runes);
-  } else if (svelteConfig?.compilerOptions?.runes != null) {
+  }
+  if (svelteConfig?.compilerOptions?.runes != null) {
     return Boolean(svelteConfig.compilerOptions.runes);
   }
   return true;

--- a/src/parser/svelte-parse-context.ts
+++ b/src/parser/svelte-parse-context.ts
@@ -28,7 +28,7 @@ export function isEnableRunes(
   } else if (svelteConfig?.compilerOptions?.runes != null) {
     return Boolean(svelteConfig.compilerOptions.runes);
   }
-  return false;
+  return true;
 }
 
 export function resolveSvelteParseContextForSvelte(

--- a/tests/fixtures/parser/ast/svelte5/$props-without-runes02-config.json
+++ b/tests/fixtures/parser/ast/svelte5/$props-without-runes02-config.json
@@ -1,5 +1,7 @@
 {
-	"svelteConfig": {
-		"runes": false
-	}
+  "svelteConfig": {
+    "compilerOptions": {
+      "runes": false
+    }
+  }
 }


### PR DESCRIPTION
Follow up of https://github.com/sveltejs/svelte-eslint-parser/pull/536#issuecomment-2173326926