### PR TITLE
fix: incorrect runes inference when having empty compiler options

### DIFF
--- a/.changeset/late-poems-collect.md
+++ b/.changeset/late-poems-collect.md
@@ -1,0 +1,5 @@
+---
+"svelte-eslint-parser": patch
+---
+
+fix: incorrect runes inference when having empty compiler options

--- a/src/svelte-config/parser.ts
+++ b/src/svelte-config/parser.ts
@@ -62,7 +62,7 @@ function parseSvelteConfigExpression(
   if (compilerOptions?.type === EvaluatedType.object) {
     result.compilerOptions = {};
     const runes = compilerOptions.getProperty("runes")?.getStatic();
-    if (runes) {
+    if (runes?.value != null) {
       result.compilerOptions.runes = Boolean(runes.value);
     }
   }
@@ -70,7 +70,7 @@ function parseSvelteConfigExpression(
   if (kit?.type === EvaluatedType.object) {
     result.kit = {};
     const files = kit.getProperty("files")?.getStatic();
-    if (files) result.kit.files = files.value as never;
+    if (files?.value != null) result.kit.files = files.value as never;
   }
   return result;
 }

--- a/tests/src/svelte-config/parser.ts
+++ b/tests/src/svelte-config/parser.ts
@@ -60,6 +60,12 @@ describe("parseConfig", () => {
         `,
       output: { compilerOptions: { runes: true } },
     },
+    {
+      code: `
+        export default {compilerOptions:{}}
+        `,
+      output: { compilerOptions: {} },
+    },
   ];
   for (const { code, output } of testCases) {
     it(code, () => {


### PR DESCRIPTION
fixes https://github.com/sveltejs/eslint-plugin-svelte/issues/849