### PR TITLE
feat: add support `{#each}` without `as` (svelte v5.4.0)

### DIFF
--- a/.changeset/witty-hairs-judge.md
+++ b/.changeset/witty-hairs-judge.md
@@ -2,4 +2,4 @@
 "svelte-eslint-parser": minor
 ---
 
-feat: add support `{#each} without `as` (svelte v5.4.0)
+feat: add support `{#each}` without `as` (svelte v5.4.0)

--- a/.changeset/witty-hairs-judge.md
+++ b/.changeset/witty-hairs-judge.md
@@ -1,0 +1,5 @@
+---
+"svelte-eslint-parser": minor
+---
+
+feat: add support `{#each} without `as` (svelte v5.4.0)

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "prettier-plugin-svelte": "^3.3.2",
     "rimraf": "^6.0.1",
     "semver": "^7.6.3",
-    "svelte": "^5.3.1",
+    "svelte": "^5.9.0",
     "svelte2tsx": "^0.7.28",
     "tsx": "^4.19.2",
     "typescript": "~5.7.2",

--- a/src/ast/html.ts
+++ b/src/ast/html.ts
@@ -347,7 +347,7 @@ export interface SvelteElseBlockElseIf extends BaseSvelteElseBlock {
 export interface SvelteEachBlock extends BaseNode {
   type: "SvelteEachBlock";
   expression: ESTree.Expression;
-  context: ESTree.Pattern;
+  context: ESTree.Pattern | null;
   index: ESTree.Identifier | null;
   key: ESTree.Expression | null;
   children: Child[];

--- a/src/parser/converts/block.ts
+++ b/src/parser/converts/block.ts
@@ -269,7 +269,7 @@ export function convertEachBlock(
   const eachBlock: SvelteEachBlock = {
     type: "SvelteEachBlock",
     expression: null as any,
-    context: null as any,
+    context: null,
     index: null,
     key: null,
     children: [],
@@ -281,7 +281,10 @@ export function convertEachBlock(
   let indexRange: null | { start: number; end: number } = null;
 
   if (node.index) {
-    const start = ctx.code.indexOf(node.index, getWithLoc(node.context).end);
+    const start = ctx.code.indexOf(
+      node.index,
+      getWithLoc(node.context ?? node.expression).end,
+    );
     indexRange = {
       start,
       end: start + node.index.length,
@@ -300,11 +303,13 @@ export function convertEachBlock(
     },
   );
 
-  const asStart = ctx.code.indexOf("as", getWithLoc(node.expression).end);
-  ctx.addToken("Keyword", {
-    start: asStart,
-    end: asStart + 2,
-  });
+  if (node.context) {
+    const asStart = ctx.code.indexOf("as", getWithLoc(node.expression).end);
+    ctx.addToken("Keyword", {
+      start: asStart,
+      end: asStart + 2,
+    });
+  }
 
   if (node.key) {
     ctx.scriptLet.addExpression(node.key, eachBlock, null, (key) => {
@@ -335,7 +340,7 @@ export function convertEachBlock(
   const elseStart = startBlockIndexForElse(
     fallbackFragment,
     body,
-    node.key || indexRange || node.context,
+    node.key || indexRange || node.context || node.expression,
     ctx,
   );
 

--- a/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/01-each-blocks-without-an-item-input.svelte
+++ b/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/01-each-blocks-without-an-item-input.svelte
@@ -1,0 +1,1 @@
+{#each expression}...{/each}

--- a/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/01-each-blocks-without-an-item-no-undef-result.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/01-each-blocks-without-an-item-no-undef-result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "ruleId": "no-undef",
+    "code": "expression",
+    "line": 1,
+    "column": 8
+  }
+]

--- a/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/01-each-blocks-without-an-item-output.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/01-each-blocks-without-an-item-output.json
@@ -1,0 +1,226 @@
+{
+  "type": "Program",
+  "body": [
+    {
+      "type": "SvelteEachBlock",
+      "expression": {
+        "type": "Identifier",
+        "name": "expression",
+        "range": [
+          7,
+          17
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 7
+          },
+          "end": {
+            "line": 1,
+            "column": 17
+          }
+        }
+      },
+      "context": null,
+      "index": null,
+      "key": null,
+      "children": [
+        {
+          "type": "SvelteText",
+          "value": "...",
+          "range": [
+            18,
+            21
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 18
+            },
+            "end": {
+              "line": 1,
+              "column": 21
+            }
+          }
+        }
+      ],
+      "else": null,
+      "range": [
+        0,
+        28
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 28
+        }
+      }
+    }
+  ],
+  "sourceType": "module",
+  "comments": [],
+  "tokens": [
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        0,
+        1
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "MustacheKeyword",
+      "value": "#each",
+      "range": [
+        1,
+        6
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 1,
+          "column": 6
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "expression",
+      "range": [
+        7,
+        17
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 7
+        },
+        "end": {
+          "line": 1,
+          "column": 17
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        17,
+        18
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 17
+        },
+        "end": {
+          "line": 1,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": "HTMLText",
+      "value": "...",
+      "range": [
+        18,
+        21
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 18
+        },
+        "end": {
+          "line": 1,
+          "column": 21
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        21,
+        22
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 21
+        },
+        "end": {
+          "line": 1,
+          "column": 22
+        }
+      }
+    },
+    {
+      "type": "MustacheKeyword",
+      "value": "/each",
+      "range": [
+        22,
+        27
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 22
+        },
+        "end": {
+          "line": 1,
+          "column": 27
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        27,
+        28
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 27
+        },
+        "end": {
+          "line": 1,
+          "column": 28
+        }
+      }
+    }
+  ],
+  "range": [
+    0,
+    29
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 0
+    }
+  }
+}

--- a/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/01-each-blocks-without-an-item-scope-output.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/01-each-blocks-without-an-item-scope-output.json
@@ -1,0 +1,156 @@
+{
+  "type": "global",
+  "variables": [
+    {
+      "name": "$$slots",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$props",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$restProps",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$state",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$derived",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$effect",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$props",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$bindable",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$inspect",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$host",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    }
+  ],
+  "references": [],
+  "childScopes": [
+    {
+      "type": "module",
+      "variables": [],
+      "references": [
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "expression",
+            "range": [
+              7,
+              17
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 7
+              },
+              "end": {
+                "line": 1,
+                "column": 17
+              }
+            }
+          },
+          "from": "module",
+          "init": null,
+          "resolved": null
+        }
+      ],
+      "childScopes": [
+        {
+          "type": "function",
+          "variables": [],
+          "references": [],
+          "childScopes": [],
+          "through": []
+        }
+      ],
+      "through": [
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "expression",
+            "range": [
+              7,
+              17
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 7
+              },
+              "end": {
+                "line": 1,
+                "column": 17
+              }
+            }
+          },
+          "from": "module",
+          "init": null,
+          "resolved": null
+        }
+      ]
+    }
+  ],
+  "through": [
+    {
+      "identifier": {
+        "type": "Identifier",
+        "name": "expression",
+        "range": [
+          7,
+          17
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 7
+          },
+          "end": {
+            "line": 1,
+            "column": 17
+          }
+        }
+      },
+      "from": "module",
+      "init": null,
+      "resolved": null
+    }
+  ]
+}

--- a/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/02-each-blocks-without-an-item-input.svelte
+++ b/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/02-each-blocks-without-an-item-input.svelte
@@ -1,0 +1,1 @@
+{#each expression, index}...{/each}

--- a/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/02-each-blocks-without-an-item-no-undef-result.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/02-each-blocks-without-an-item-no-undef-result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "ruleId": "no-undef",
+    "code": "expression",
+    "line": 1,
+    "column": 8
+  }
+]

--- a/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/02-each-blocks-without-an-item-no-unused-vars-result.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/02-each-blocks-without-an-item-no-unused-vars-result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "ruleId": "no-unused-vars",
+    "code": "index",
+    "line": 1,
+    "column": 20
+  }
+]

--- a/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/02-each-blocks-without-an-item-output.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/02-each-blocks-without-an-item-output.json
@@ -1,0 +1,279 @@
+{
+  "type": "Program",
+  "body": [
+    {
+      "type": "SvelteEachBlock",
+      "expression": {
+        "type": "Identifier",
+        "name": "expression",
+        "range": [
+          7,
+          17
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 7
+          },
+          "end": {
+            "line": 1,
+            "column": 17
+          }
+        }
+      },
+      "context": null,
+      "index": {
+        "type": "Identifier",
+        "name": "index",
+        "range": [
+          19,
+          24
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 19
+          },
+          "end": {
+            "line": 1,
+            "column": 24
+          }
+        }
+      },
+      "key": null,
+      "children": [
+        {
+          "type": "SvelteText",
+          "value": "...",
+          "range": [
+            25,
+            28
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 25
+            },
+            "end": {
+              "line": 1,
+              "column": 28
+            }
+          }
+        }
+      ],
+      "else": null,
+      "range": [
+        0,
+        35
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 35
+        }
+      }
+    }
+  ],
+  "sourceType": "module",
+  "comments": [],
+  "tokens": [
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        0,
+        1
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "MustacheKeyword",
+      "value": "#each",
+      "range": [
+        1,
+        6
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 1,
+          "column": 6
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "expression",
+      "range": [
+        7,
+        17
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 7
+        },
+        "end": {
+          "line": 1,
+          "column": 17
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ",",
+      "range": [
+        17,
+        18
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 17
+        },
+        "end": {
+          "line": 1,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "index",
+      "range": [
+        19,
+        24
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 19
+        },
+        "end": {
+          "line": 1,
+          "column": 24
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        24,
+        25
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 24
+        },
+        "end": {
+          "line": 1,
+          "column": 25
+        }
+      }
+    },
+    {
+      "type": "HTMLText",
+      "value": "...",
+      "range": [
+        25,
+        28
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 25
+        },
+        "end": {
+          "line": 1,
+          "column": 28
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        28,
+        29
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 28
+        },
+        "end": {
+          "line": 1,
+          "column": 29
+        }
+      }
+    },
+    {
+      "type": "MustacheKeyword",
+      "value": "/each",
+      "range": [
+        29,
+        34
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 29
+        },
+        "end": {
+          "line": 1,
+          "column": 34
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        34,
+        35
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 34
+        },
+        "end": {
+          "line": 1,
+          "column": 35
+        }
+      }
+    }
+  ],
+  "range": [
+    0,
+    36
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 0
+    }
+  }
+}

--- a/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/02-each-blocks-without-an-item-scope-output.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/02-each-blocks-without-an-item-scope-output.json
@@ -1,0 +1,280 @@
+{
+  "type": "global",
+  "variables": [
+    {
+      "name": "$$slots",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$props",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$restProps",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$state",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$derived",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$effect",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$props",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$bindable",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$inspect",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$host",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    }
+  ],
+  "references": [],
+  "childScopes": [
+    {
+      "type": "module",
+      "variables": [],
+      "references": [
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "expression",
+            "range": [
+              7,
+              17
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 7
+              },
+              "end": {
+                "line": 1,
+                "column": 17
+              }
+            }
+          },
+          "from": "module",
+          "init": null,
+          "resolved": null
+        }
+      ],
+      "childScopes": [
+        {
+          "type": "function",
+          "variables": [
+            {
+              "name": "index",
+              "identifiers": [
+                {
+                  "type": "Identifier",
+                  "name": "index",
+                  "range": [
+                    19,
+                    24
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 19
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 24
+                    }
+                  }
+                }
+              ],
+              "defs": [
+                {
+                  "type": "Parameter",
+                  "name": {
+                    "type": "Identifier",
+                    "name": "index",
+                    "range": [
+                      19,
+                      24
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 19
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 24
+                      }
+                    }
+                  },
+                  "node": {
+                    "type": "SvelteEachBlock",
+                    "expression": {
+                      "type": "Identifier",
+                      "name": "expression",
+                      "range": [
+                        7,
+                        17
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 7
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 17
+                        }
+                      }
+                    },
+                    "context": null,
+                    "index": {
+                      "type": "Identifier",
+                      "name": "index",
+                      "range": [
+                        19,
+                        24
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 19
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 24
+                        }
+                      }
+                    },
+                    "key": null,
+                    "children": [
+                      {
+                        "type": "SvelteText",
+                        "value": "...",
+                        "range": [
+                          25,
+                          28
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 1,
+                            "column": 25
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 28
+                          }
+                        }
+                      }
+                    ],
+                    "else": null,
+                    "range": [
+                      0,
+                      35
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 0
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 35
+                      }
+                    }
+                  }
+                }
+              ],
+              "references": []
+            }
+          ],
+          "references": [],
+          "childScopes": [],
+          "through": []
+        }
+      ],
+      "through": [
+        {
+          "identifier": {
+            "type": "Identifier",
+            "name": "expression",
+            "range": [
+              7,
+              17
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 7
+              },
+              "end": {
+                "line": 1,
+                "column": 17
+              }
+            }
+          },
+          "from": "module",
+          "init": null,
+          "resolved": null
+        }
+      ]
+    }
+  ],
+  "through": [
+    {
+      "identifier": {
+        "type": "Identifier",
+        "name": "expression",
+        "range": [
+          7,
+          17
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 7
+          },
+          "end": {
+            "line": 1,
+            "column": 17
+          }
+        }
+      },
+      "from": "module",
+      "init": null,
+      "resolved": null
+    }
+  ]
+}

--- a/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/03-each-blocks-without-an-item-input.svelte
+++ b/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/03-each-blocks-without-an-item-input.svelte
@@ -1,0 +1,7 @@
+<div class="chess-board">
+	{#each { length: 8 }, rank}
+		{#each { length: 8 }, file}
+			<div class:black={(rank + file) % 2 === 1}></div>
+		{/each}
+	{/each}
+</div>

--- a/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/03-each-blocks-without-an-item-output.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/03-each-blocks-without-an-item-output.json
@@ -1,0 +1,1797 @@
+{
+  "type": "Program",
+  "body": [
+    {
+      "type": "SvelteElement",
+      "kind": "html",
+      "name": {
+        "type": "SvelteName",
+        "name": "div",
+        "range": [
+          1,
+          4
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 4
+          }
+        }
+      },
+      "startTag": {
+        "type": "SvelteStartTag",
+        "attributes": [
+          {
+            "type": "SvelteAttribute",
+            "key": {
+              "type": "SvelteName",
+              "name": "class",
+              "range": [
+                5,
+                10
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 5
+                },
+                "end": {
+                  "line": 1,
+                  "column": 10
+                }
+              }
+            },
+            "boolean": false,
+            "value": [
+              {
+                "type": "SvelteLiteral",
+                "value": "chess-board",
+                "range": [
+                  12,
+                  23
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 23
+                  }
+                }
+              }
+            ],
+            "range": [
+              5,
+              24
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 5
+              },
+              "end": {
+                "line": 1,
+                "column": 24
+              }
+            }
+          }
+        ],
+        "selfClosing": false,
+        "range": [
+          0,
+          25
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 25
+          }
+        }
+      },
+      "children": [
+        {
+          "type": "SvelteText",
+          "value": "\n\t",
+          "range": [
+            25,
+            27
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 25
+            },
+            "end": {
+              "line": 2,
+              "column": 1
+            }
+          }
+        },
+        {
+          "type": "SvelteEachBlock",
+          "expression": {
+            "type": "ObjectExpression",
+            "properties": [
+              {
+                "type": "Property",
+                "kind": "init",
+                "computed": false,
+                "key": {
+                  "type": "Identifier",
+                  "name": "length",
+                  "range": [
+                    36,
+                    42
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 10
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 16
+                    }
+                  }
+                },
+                "method": false,
+                "shorthand": false,
+                "value": {
+                  "type": "Literal",
+                  "raw": "8",
+                  "value": 8,
+                  "range": [
+                    44,
+                    45
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 18
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 19
+                    }
+                  }
+                },
+                "range": [
+                  36,
+                  45
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 19
+                  }
+                }
+              }
+            ],
+            "range": [
+              34,
+              47
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 8
+              },
+              "end": {
+                "line": 2,
+                "column": 21
+              }
+            }
+          },
+          "context": null,
+          "index": {
+            "type": "Identifier",
+            "name": "rank",
+            "range": [
+              49,
+              53
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 23
+              },
+              "end": {
+                "line": 2,
+                "column": 27
+              }
+            }
+          },
+          "key": null,
+          "children": [
+            {
+              "type": "SvelteEachBlock",
+              "expression": {
+                "type": "ObjectExpression",
+                "properties": [
+                  {
+                    "type": "Property",
+                    "kind": "init",
+                    "computed": false,
+                    "key": {
+                      "type": "Identifier",
+                      "name": "length",
+                      "range": [
+                        66,
+                        72
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 11
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 17
+                        }
+                      }
+                    },
+                    "method": false,
+                    "shorthand": false,
+                    "value": {
+                      "type": "Literal",
+                      "raw": "8",
+                      "value": 8,
+                      "range": [
+                        74,
+                        75
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 19
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 20
+                        }
+                      }
+                    },
+                    "range": [
+                      66,
+                      75
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 11
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 20
+                      }
+                    }
+                  }
+                ],
+                "range": [
+                  64,
+                  77
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 22
+                  }
+                }
+              },
+              "context": null,
+              "index": {
+                "type": "Identifier",
+                "name": "file",
+                "range": [
+                  79,
+                  83
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 24
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 28
+                  }
+                }
+              },
+              "key": null,
+              "children": [
+                {
+                  "type": "SvelteElement",
+                  "kind": "html",
+                  "name": {
+                    "type": "SvelteName",
+                    "name": "div",
+                    "range": [
+                      89,
+                      92
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 4
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 7
+                      }
+                    }
+                  },
+                  "startTag": {
+                    "type": "SvelteStartTag",
+                    "attributes": [
+                      {
+                        "type": "SvelteDirective",
+                        "kind": "Class",
+                        "key": {
+                          "type": "SvelteDirectiveKey",
+                          "name": {
+                            "type": "SvelteName",
+                            "name": "black",
+                            "range": [
+                              99,
+                              104
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 4,
+                                "column": 14
+                              },
+                              "end": {
+                                "line": 4,
+                                "column": 19
+                              }
+                            }
+                          },
+                          "modifiers": [],
+                          "range": [
+                            93,
+                            104
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 4,
+                              "column": 8
+                            },
+                            "end": {
+                              "line": 4,
+                              "column": 19
+                            }
+                          }
+                        },
+                        "expression": {
+                          "type": "BinaryExpression",
+                          "left": {
+                            "type": "BinaryExpression",
+                            "left": {
+                              "type": "BinaryExpression",
+                              "left": {
+                                "type": "Identifier",
+                                "name": "rank",
+                                "range": [
+                                  107,
+                                  111
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 4,
+                                    "column": 22
+                                  },
+                                  "end": {
+                                    "line": 4,
+                                    "column": 26
+                                  }
+                                }
+                              },
+                              "operator": "+",
+                              "right": {
+                                "type": "Identifier",
+                                "name": "file",
+                                "range": [
+                                  114,
+                                  118
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 4,
+                                    "column": 29
+                                  },
+                                  "end": {
+                                    "line": 4,
+                                    "column": 33
+                                  }
+                                }
+                              },
+                              "range": [
+                                107,
+                                118
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 4,
+                                  "column": 22
+                                },
+                                "end": {
+                                  "line": 4,
+                                  "column": 33
+                                }
+                              }
+                            },
+                            "operator": "%",
+                            "right": {
+                              "type": "Literal",
+                              "raw": "2",
+                              "value": 2,
+                              "range": [
+                                122,
+                                123
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 4,
+                                  "column": 37
+                                },
+                                "end": {
+                                  "line": 4,
+                                  "column": 38
+                                }
+                              }
+                            },
+                            "range": [
+                              106,
+                              123
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 4,
+                                "column": 21
+                              },
+                              "end": {
+                                "line": 4,
+                                "column": 38
+                              }
+                            }
+                          },
+                          "operator": "===",
+                          "right": {
+                            "type": "Literal",
+                            "raw": "1",
+                            "value": 1,
+                            "range": [
+                              128,
+                              129
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 4,
+                                "column": 43
+                              },
+                              "end": {
+                                "line": 4,
+                                "column": 44
+                              }
+                            }
+                          },
+                          "range": [
+                            106,
+                            129
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 4,
+                              "column": 21
+                            },
+                            "end": {
+                              "line": 4,
+                              "column": 44
+                            }
+                          }
+                        },
+                        "shorthand": false,
+                        "range": [
+                          93,
+                          130
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 4,
+                            "column": 8
+                          },
+                          "end": {
+                            "line": 4,
+                            "column": 45
+                          }
+                        }
+                      }
+                    ],
+                    "selfClosing": false,
+                    "range": [
+                      88,
+                      131
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 3
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 46
+                      }
+                    }
+                  },
+                  "children": [],
+                  "endTag": {
+                    "type": "SvelteEndTag",
+                    "range": [
+                      131,
+                      137
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 46
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 52
+                      }
+                    }
+                  },
+                  "range": [
+                    88,
+                    137
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 3
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 52
+                    }
+                  }
+                }
+              ],
+              "else": null,
+              "range": [
+                57,
+                147
+              ],
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 5,
+                  "column": 9
+                }
+              }
+            }
+          ],
+          "else": null,
+          "range": [
+            27,
+            156
+          ],
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 1
+            },
+            "end": {
+              "line": 6,
+              "column": 8
+            }
+          }
+        },
+        {
+          "type": "SvelteText",
+          "value": "\n",
+          "range": [
+            156,
+            157
+          ],
+          "loc": {
+            "start": {
+              "line": 6,
+              "column": 8
+            },
+            "end": {
+              "line": 7,
+              "column": 0
+            }
+          }
+        }
+      ],
+      "endTag": {
+        "type": "SvelteEndTag",
+        "range": [
+          157,
+          163
+        ],
+        "loc": {
+          "start": {
+            "line": 7,
+            "column": 0
+          },
+          "end": {
+            "line": 7,
+            "column": 6
+          }
+        }
+      },
+      "range": [
+        0,
+        163
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 7,
+          "column": 6
+        }
+      }
+    }
+  ],
+  "sourceType": "module",
+  "comments": [],
+  "tokens": [
+    {
+      "type": "Punctuator",
+      "value": "<",
+      "range": [
+        0,
+        1
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "div",
+      "range": [
+        1,
+        4
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 1,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "class",
+      "range": [
+        5,
+        10
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 5
+        },
+        "end": {
+          "line": 1,
+          "column": 10
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "=",
+      "range": [
+        10,
+        11
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 10
+        },
+        "end": {
+          "line": 1,
+          "column": 11
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "\"",
+      "range": [
+        11,
+        12
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 11
+        },
+        "end": {
+          "line": 1,
+          "column": 12
+        }
+      }
+    },
+    {
+      "type": "HTMLText",
+      "value": "chess-board",
+      "range": [
+        12,
+        23
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 12
+        },
+        "end": {
+          "line": 1,
+          "column": 23
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "\"",
+      "range": [
+        23,
+        24
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 23
+        },
+        "end": {
+          "line": 1,
+          "column": 24
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ">",
+      "range": [
+        24,
+        25
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 24
+        },
+        "end": {
+          "line": 1,
+          "column": 25
+        }
+      }
+    },
+    {
+      "type": "HTMLText",
+      "value": "\n\t",
+      "range": [
+        25,
+        27
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 25
+        },
+        "end": {
+          "line": 2,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        27,
+        28
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 1
+        },
+        "end": {
+          "line": 2,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": "MustacheKeyword",
+      "value": "#each",
+      "range": [
+        28,
+        33
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 2,
+          "column": 7
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        34,
+        35
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 8
+        },
+        "end": {
+          "line": 2,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "length",
+      "range": [
+        36,
+        42
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 10
+        },
+        "end": {
+          "line": 2,
+          "column": 16
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ":",
+      "range": [
+        42,
+        43
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 16
+        },
+        "end": {
+          "line": 2,
+          "column": 17
+        }
+      }
+    },
+    {
+      "type": "Numeric",
+      "value": "8",
+      "range": [
+        44,
+        45
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 18
+        },
+        "end": {
+          "line": 2,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        46,
+        47
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 20
+        },
+        "end": {
+          "line": 2,
+          "column": 21
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ",",
+      "range": [
+        47,
+        48
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 21
+        },
+        "end": {
+          "line": 2,
+          "column": 22
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "rank",
+      "range": [
+        49,
+        53
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 23
+        },
+        "end": {
+          "line": 2,
+          "column": 27
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        53,
+        54
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 27
+        },
+        "end": {
+          "line": 2,
+          "column": 28
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        57,
+        58
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 2
+        },
+        "end": {
+          "line": 3,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": "MustacheKeyword",
+      "value": "#each",
+      "range": [
+        58,
+        63
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 3
+        },
+        "end": {
+          "line": 3,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        64,
+        65
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 9
+        },
+        "end": {
+          "line": 3,
+          "column": 10
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "length",
+      "range": [
+        66,
+        72
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 11
+        },
+        "end": {
+          "line": 3,
+          "column": 17
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ":",
+      "range": [
+        72,
+        73
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 17
+        },
+        "end": {
+          "line": 3,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": "Numeric",
+      "value": "8",
+      "range": [
+        74,
+        75
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 19
+        },
+        "end": {
+          "line": 3,
+          "column": 20
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        76,
+        77
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 21
+        },
+        "end": {
+          "line": 3,
+          "column": 22
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ",",
+      "range": [
+        77,
+        78
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 22
+        },
+        "end": {
+          "line": 3,
+          "column": 23
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "file",
+      "range": [
+        79,
+        83
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 24
+        },
+        "end": {
+          "line": 3,
+          "column": 28
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        83,
+        84
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 28
+        },
+        "end": {
+          "line": 3,
+          "column": 29
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "<",
+      "range": [
+        88,
+        89
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 3
+        },
+        "end": {
+          "line": 4,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "div",
+      "range": [
+        89,
+        92
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 4
+        },
+        "end": {
+          "line": 4,
+          "column": 7
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "class",
+      "range": [
+        93,
+        98
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 8
+        },
+        "end": {
+          "line": 4,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ":",
+      "range": [
+        98,
+        99
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 13
+        },
+        "end": {
+          "line": 4,
+          "column": 14
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "black",
+      "range": [
+        99,
+        104
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 14
+        },
+        "end": {
+          "line": 4,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "=",
+      "range": [
+        104,
+        105
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 19
+        },
+        "end": {
+          "line": 4,
+          "column": 20
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        105,
+        106
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 20
+        },
+        "end": {
+          "line": 4,
+          "column": 21
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "(",
+      "range": [
+        106,
+        107
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 21
+        },
+        "end": {
+          "line": 4,
+          "column": 22
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "rank",
+      "range": [
+        107,
+        111
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 22
+        },
+        "end": {
+          "line": 4,
+          "column": 26
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "+",
+      "range": [
+        112,
+        113
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 27
+        },
+        "end": {
+          "line": 4,
+          "column": 28
+        }
+      }
+    },
+    {
+      "type": "Identifier",
+      "value": "file",
+      "range": [
+        114,
+        118
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 29
+        },
+        "end": {
+          "line": 4,
+          "column": 33
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ")",
+      "range": [
+        118,
+        119
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 33
+        },
+        "end": {
+          "line": 4,
+          "column": 34
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "%",
+      "range": [
+        120,
+        121
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 35
+        },
+        "end": {
+          "line": 4,
+          "column": 36
+        }
+      }
+    },
+    {
+      "type": "Numeric",
+      "value": "2",
+      "range": [
+        122,
+        123
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 37
+        },
+        "end": {
+          "line": 4,
+          "column": 38
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "===",
+      "range": [
+        124,
+        127
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 39
+        },
+        "end": {
+          "line": 4,
+          "column": 42
+        }
+      }
+    },
+    {
+      "type": "Numeric",
+      "value": "1",
+      "range": [
+        128,
+        129
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 43
+        },
+        "end": {
+          "line": 4,
+          "column": 44
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        129,
+        130
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 44
+        },
+        "end": {
+          "line": 4,
+          "column": 45
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ">",
+      "range": [
+        130,
+        131
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 45
+        },
+        "end": {
+          "line": 4,
+          "column": 46
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "<",
+      "range": [
+        131,
+        132
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 46
+        },
+        "end": {
+          "line": 4,
+          "column": 47
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "/",
+      "range": [
+        132,
+        133
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 47
+        },
+        "end": {
+          "line": 4,
+          "column": 48
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "div",
+      "range": [
+        133,
+        136
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 48
+        },
+        "end": {
+          "line": 4,
+          "column": 51
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ">",
+      "range": [
+        136,
+        137
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 51
+        },
+        "end": {
+          "line": 4,
+          "column": 52
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        140,
+        141
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 2
+        },
+        "end": {
+          "line": 5,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": "MustacheKeyword",
+      "value": "/each",
+      "range": [
+        141,
+        146
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 3
+        },
+        "end": {
+          "line": 5,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        146,
+        147
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 8
+        },
+        "end": {
+          "line": 5,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        149,
+        150
+      ],
+      "loc": {
+        "start": {
+          "line": 6,
+          "column": 1
+        },
+        "end": {
+          "line": 6,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": "MustacheKeyword",
+      "value": "/each",
+      "range": [
+        150,
+        155
+      ],
+      "loc": {
+        "start": {
+          "line": 6,
+          "column": 2
+        },
+        "end": {
+          "line": 6,
+          "column": 7
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        155,
+        156
+      ],
+      "loc": {
+        "start": {
+          "line": 6,
+          "column": 7
+        },
+        "end": {
+          "line": 6,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": "HTMLText",
+      "value": "\n",
+      "range": [
+        156,
+        157
+      ],
+      "loc": {
+        "start": {
+          "line": 6,
+          "column": 8
+        },
+        "end": {
+          "line": 7,
+          "column": 0
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "<",
+      "range": [
+        157,
+        158
+      ],
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 0
+        },
+        "end": {
+          "line": 7,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "/",
+      "range": [
+        158,
+        159
+      ],
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 1
+        },
+        "end": {
+          "line": 7,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": "HTMLIdentifier",
+      "value": "div",
+      "range": [
+        159,
+        162
+      ],
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 2
+        },
+        "end": {
+          "line": 7,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": ">",
+      "range": [
+        162,
+        163
+      ],
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 5
+        },
+        "end": {
+          "line": 7,
+          "column": 6
+        }
+      }
+    }
+  ],
+  "range": [
+    0,
+    164
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 8,
+      "column": 0
+    }
+  }
+}

--- a/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/03-each-blocks-without-an-item-scope-output.json
+++ b/tests/fixtures/parser/ast/svelte5/docs/template-syntax/03-each/03-each-blocks-without-an-item-scope-output.json
@@ -1,0 +1,1257 @@
+{
+  "type": "global",
+  "variables": [
+    {
+      "name": "$$slots",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$props",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$restProps",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$state",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$derived",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$effect",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$props",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$bindable",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$inspect",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$host",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    }
+  ],
+  "references": [],
+  "childScopes": [
+    {
+      "type": "module",
+      "variables": [],
+      "references": [],
+      "childScopes": [
+        {
+          "type": "function",
+          "variables": [
+            {
+              "name": "rank",
+              "identifiers": [
+                {
+                  "type": "Identifier",
+                  "name": "rank",
+                  "range": [
+                    49,
+                    53
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 2,
+                      "column": 23
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 27
+                    }
+                  }
+                }
+              ],
+              "defs": [
+                {
+                  "type": "Parameter",
+                  "name": {
+                    "type": "Identifier",
+                    "name": "rank",
+                    "range": [
+                      49,
+                      53
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 23
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 27
+                      }
+                    }
+                  },
+                  "node": {
+                    "type": "SvelteEachBlock",
+                    "expression": {
+                      "type": "ObjectExpression",
+                      "properties": [
+                        {
+                          "type": "Property",
+                          "kind": "init",
+                          "computed": false,
+                          "key": {
+                            "type": "Identifier",
+                            "name": "length",
+                            "range": [
+                              36,
+                              42
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 2,
+                                "column": 10
+                              },
+                              "end": {
+                                "line": 2,
+                                "column": 16
+                              }
+                            }
+                          },
+                          "method": false,
+                          "shorthand": false,
+                          "value": {
+                            "type": "Literal",
+                            "raw": "8",
+                            "value": 8,
+                            "range": [
+                              44,
+                              45
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 2,
+                                "column": 18
+                              },
+                              "end": {
+                                "line": 2,
+                                "column": 19
+                              }
+                            }
+                          },
+                          "range": [
+                            36,
+                            45
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 2,
+                              "column": 10
+                            },
+                            "end": {
+                              "line": 2,
+                              "column": 19
+                            }
+                          }
+                        }
+                      ],
+                      "range": [
+                        34,
+                        47
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 8
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 21
+                        }
+                      }
+                    },
+                    "context": null,
+                    "index": {
+                      "type": "Identifier",
+                      "name": "rank",
+                      "range": [
+                        49,
+                        53
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 23
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 27
+                        }
+                      }
+                    },
+                    "key": null,
+                    "children": [
+                      {
+                        "type": "SvelteEachBlock",
+                        "expression": {
+                          "type": "ObjectExpression",
+                          "properties": [
+                            {
+                              "type": "Property",
+                              "kind": "init",
+                              "computed": false,
+                              "key": {
+                                "type": "Identifier",
+                                "name": "length",
+                                "range": [
+                                  66,
+                                  72
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 3,
+                                    "column": 11
+                                  },
+                                  "end": {
+                                    "line": 3,
+                                    "column": 17
+                                  }
+                                }
+                              },
+                              "method": false,
+                              "shorthand": false,
+                              "value": {
+                                "type": "Literal",
+                                "raw": "8",
+                                "value": 8,
+                                "range": [
+                                  74,
+                                  75
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 3,
+                                    "column": 19
+                                  },
+                                  "end": {
+                                    "line": 3,
+                                    "column": 20
+                                  }
+                                }
+                              },
+                              "range": [
+                                66,
+                                75
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 3,
+                                  "column": 11
+                                },
+                                "end": {
+                                  "line": 3,
+                                  "column": 20
+                                }
+                              }
+                            }
+                          ],
+                          "range": [
+                            64,
+                            77
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 3,
+                              "column": 9
+                            },
+                            "end": {
+                              "line": 3,
+                              "column": 22
+                            }
+                          }
+                        },
+                        "context": null,
+                        "index": {
+                          "type": "Identifier",
+                          "name": "file",
+                          "range": [
+                            79,
+                            83
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 3,
+                              "column": 24
+                            },
+                            "end": {
+                              "line": 3,
+                              "column": 28
+                            }
+                          }
+                        },
+                        "key": null,
+                        "children": [
+                          {
+                            "type": "SvelteElement",
+                            "kind": "html",
+                            "name": {
+                              "type": "SvelteName",
+                              "name": "div",
+                              "range": [
+                                89,
+                                92
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 4,
+                                  "column": 4
+                                },
+                                "end": {
+                                  "line": 4,
+                                  "column": 7
+                                }
+                              }
+                            },
+                            "startTag": {
+                              "type": "SvelteStartTag",
+                              "attributes": [
+                                {
+                                  "type": "SvelteDirective",
+                                  "kind": "Class",
+                                  "key": {
+                                    "type": "SvelteDirectiveKey",
+                                    "name": {
+                                      "type": "SvelteName",
+                                      "name": "black",
+                                      "range": [
+                                        99,
+                                        104
+                                      ],
+                                      "loc": {
+                                        "start": {
+                                          "line": 4,
+                                          "column": 14
+                                        },
+                                        "end": {
+                                          "line": 4,
+                                          "column": 19
+                                        }
+                                      }
+                                    },
+                                    "modifiers": [],
+                                    "range": [
+                                      93,
+                                      104
+                                    ],
+                                    "loc": {
+                                      "start": {
+                                        "line": 4,
+                                        "column": 8
+                                      },
+                                      "end": {
+                                        "line": 4,
+                                        "column": 19
+                                      }
+                                    }
+                                  },
+                                  "expression": {
+                                    "type": "BinaryExpression",
+                                    "left": {
+                                      "type": "BinaryExpression",
+                                      "left": {
+                                        "type": "BinaryExpression",
+                                        "left": {
+                                          "type": "Identifier",
+                                          "name": "rank",
+                                          "range": [
+                                            107,
+                                            111
+                                          ],
+                                          "loc": {
+                                            "start": {
+                                              "line": 4,
+                                              "column": 22
+                                            },
+                                            "end": {
+                                              "line": 4,
+                                              "column": 26
+                                            }
+                                          }
+                                        },
+                                        "operator": "+",
+                                        "right": {
+                                          "type": "Identifier",
+                                          "name": "file",
+                                          "range": [
+                                            114,
+                                            118
+                                          ],
+                                          "loc": {
+                                            "start": {
+                                              "line": 4,
+                                              "column": 29
+                                            },
+                                            "end": {
+                                              "line": 4,
+                                              "column": 33
+                                            }
+                                          }
+                                        },
+                                        "range": [
+                                          107,
+                                          118
+                                        ],
+                                        "loc": {
+                                          "start": {
+                                            "line": 4,
+                                            "column": 22
+                                          },
+                                          "end": {
+                                            "line": 4,
+                                            "column": 33
+                                          }
+                                        }
+                                      },
+                                      "operator": "%",
+                                      "right": {
+                                        "type": "Literal",
+                                        "raw": "2",
+                                        "value": 2,
+                                        "range": [
+                                          122,
+                                          123
+                                        ],
+                                        "loc": {
+                                          "start": {
+                                            "line": 4,
+                                            "column": 37
+                                          },
+                                          "end": {
+                                            "line": 4,
+                                            "column": 38
+                                          }
+                                        }
+                                      },
+                                      "range": [
+                                        106,
+                                        123
+                                      ],
+                                      "loc": {
+                                        "start": {
+                                          "line": 4,
+                                          "column": 21
+                                        },
+                                        "end": {
+                                          "line": 4,
+                                          "column": 38
+                                        }
+                                      }
+                                    },
+                                    "operator": "===",
+                                    "right": {
+                                      "type": "Literal",
+                                      "raw": "1",
+                                      "value": 1,
+                                      "range": [
+                                        128,
+                                        129
+                                      ],
+                                      "loc": {
+                                        "start": {
+                                          "line": 4,
+                                          "column": 43
+                                        },
+                                        "end": {
+                                          "line": 4,
+                                          "column": 44
+                                        }
+                                      }
+                                    },
+                                    "range": [
+                                      106,
+                                      129
+                                    ],
+                                    "loc": {
+                                      "start": {
+                                        "line": 4,
+                                        "column": 21
+                                      },
+                                      "end": {
+                                        "line": 4,
+                                        "column": 44
+                                      }
+                                    }
+                                  },
+                                  "shorthand": false,
+                                  "range": [
+                                    93,
+                                    130
+                                  ],
+                                  "loc": {
+                                    "start": {
+                                      "line": 4,
+                                      "column": 8
+                                    },
+                                    "end": {
+                                      "line": 4,
+                                      "column": 45
+                                    }
+                                  }
+                                }
+                              ],
+                              "selfClosing": false,
+                              "range": [
+                                88,
+                                131
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 4,
+                                  "column": 3
+                                },
+                                "end": {
+                                  "line": 4,
+                                  "column": 46
+                                }
+                              }
+                            },
+                            "children": [],
+                            "endTag": {
+                              "type": "SvelteEndTag",
+                              "range": [
+                                131,
+                                137
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 4,
+                                  "column": 46
+                                },
+                                "end": {
+                                  "line": 4,
+                                  "column": 52
+                                }
+                              }
+                            },
+                            "range": [
+                              88,
+                              137
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 4,
+                                "column": 3
+                              },
+                              "end": {
+                                "line": 4,
+                                "column": 52
+                              }
+                            }
+                          }
+                        ],
+                        "else": null,
+                        "range": [
+                          57,
+                          147
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 2
+                          },
+                          "end": {
+                            "line": 5,
+                            "column": 9
+                          }
+                        }
+                      }
+                    ],
+                    "else": null,
+                    "range": [
+                      27,
+                      156
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 1
+                      },
+                      "end": {
+                        "line": 6,
+                        "column": 8
+                      }
+                    }
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "identifier": {
+                    "type": "Identifier",
+                    "name": "rank",
+                    "range": [
+                      107,
+                      111
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 22
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 26
+                      }
+                    }
+                  },
+                  "from": "function",
+                  "init": null,
+                  "resolved": {
+                    "type": "Identifier",
+                    "name": "rank",
+                    "range": [
+                      49,
+                      53
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 23
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 27
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "references": [],
+          "childScopes": [
+            {
+              "type": "function",
+              "variables": [
+                {
+                  "name": "file",
+                  "identifiers": [
+                    {
+                      "type": "Identifier",
+                      "name": "file",
+                      "range": [
+                        79,
+                        83
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 24
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 28
+                        }
+                      }
+                    }
+                  ],
+                  "defs": [
+                    {
+                      "type": "Parameter",
+                      "name": {
+                        "type": "Identifier",
+                        "name": "file",
+                        "range": [
+                          79,
+                          83
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 24
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 28
+                          }
+                        }
+                      },
+                      "node": {
+                        "type": "SvelteEachBlock",
+                        "expression": {
+                          "type": "ObjectExpression",
+                          "properties": [
+                            {
+                              "type": "Property",
+                              "kind": "init",
+                              "computed": false,
+                              "key": {
+                                "type": "Identifier",
+                                "name": "length",
+                                "range": [
+                                  66,
+                                  72
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 3,
+                                    "column": 11
+                                  },
+                                  "end": {
+                                    "line": 3,
+                                    "column": 17
+                                  }
+                                }
+                              },
+                              "method": false,
+                              "shorthand": false,
+                              "value": {
+                                "type": "Literal",
+                                "raw": "8",
+                                "value": 8,
+                                "range": [
+                                  74,
+                                  75
+                                ],
+                                "loc": {
+                                  "start": {
+                                    "line": 3,
+                                    "column": 19
+                                  },
+                                  "end": {
+                                    "line": 3,
+                                    "column": 20
+                                  }
+                                }
+                              },
+                              "range": [
+                                66,
+                                75
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 3,
+                                  "column": 11
+                                },
+                                "end": {
+                                  "line": 3,
+                                  "column": 20
+                                }
+                              }
+                            }
+                          ],
+                          "range": [
+                            64,
+                            77
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 3,
+                              "column": 9
+                            },
+                            "end": {
+                              "line": 3,
+                              "column": 22
+                            }
+                          }
+                        },
+                        "context": null,
+                        "index": {
+                          "type": "Identifier",
+                          "name": "file",
+                          "range": [
+                            79,
+                            83
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 3,
+                              "column": 24
+                            },
+                            "end": {
+                              "line": 3,
+                              "column": 28
+                            }
+                          }
+                        },
+                        "key": null,
+                        "children": [
+                          {
+                            "type": "SvelteElement",
+                            "kind": "html",
+                            "name": {
+                              "type": "SvelteName",
+                              "name": "div",
+                              "range": [
+                                89,
+                                92
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 4,
+                                  "column": 4
+                                },
+                                "end": {
+                                  "line": 4,
+                                  "column": 7
+                                }
+                              }
+                            },
+                            "startTag": {
+                              "type": "SvelteStartTag",
+                              "attributes": [
+                                {
+                                  "type": "SvelteDirective",
+                                  "kind": "Class",
+                                  "key": {
+                                    "type": "SvelteDirectiveKey",
+                                    "name": {
+                                      "type": "SvelteName",
+                                      "name": "black",
+                                      "range": [
+                                        99,
+                                        104
+                                      ],
+                                      "loc": {
+                                        "start": {
+                                          "line": 4,
+                                          "column": 14
+                                        },
+                                        "end": {
+                                          "line": 4,
+                                          "column": 19
+                                        }
+                                      }
+                                    },
+                                    "modifiers": [],
+                                    "range": [
+                                      93,
+                                      104
+                                    ],
+                                    "loc": {
+                                      "start": {
+                                        "line": 4,
+                                        "column": 8
+                                      },
+                                      "end": {
+                                        "line": 4,
+                                        "column": 19
+                                      }
+                                    }
+                                  },
+                                  "expression": {
+                                    "type": "BinaryExpression",
+                                    "left": {
+                                      "type": "BinaryExpression",
+                                      "left": {
+                                        "type": "BinaryExpression",
+                                        "left": {
+                                          "type": "Identifier",
+                                          "name": "rank",
+                                          "range": [
+                                            107,
+                                            111
+                                          ],
+                                          "loc": {
+                                            "start": {
+                                              "line": 4,
+                                              "column": 22
+                                            },
+                                            "end": {
+                                              "line": 4,
+                                              "column": 26
+                                            }
+                                          }
+                                        },
+                                        "operator": "+",
+                                        "right": {
+                                          "type": "Identifier",
+                                          "name": "file",
+                                          "range": [
+                                            114,
+                                            118
+                                          ],
+                                          "loc": {
+                                            "start": {
+                                              "line": 4,
+                                              "column": 29
+                                            },
+                                            "end": {
+                                              "line": 4,
+                                              "column": 33
+                                            }
+                                          }
+                                        },
+                                        "range": [
+                                          107,
+                                          118
+                                        ],
+                                        "loc": {
+                                          "start": {
+                                            "line": 4,
+                                            "column": 22
+                                          },
+                                          "end": {
+                                            "line": 4,
+                                            "column": 33
+                                          }
+                                        }
+                                      },
+                                      "operator": "%",
+                                      "right": {
+                                        "type": "Literal",
+                                        "raw": "2",
+                                        "value": 2,
+                                        "range": [
+                                          122,
+                                          123
+                                        ],
+                                        "loc": {
+                                          "start": {
+                                            "line": 4,
+                                            "column": 37
+                                          },
+                                          "end": {
+                                            "line": 4,
+                                            "column": 38
+                                          }
+                                        }
+                                      },
+                                      "range": [
+                                        106,
+                                        123
+                                      ],
+                                      "loc": {
+                                        "start": {
+                                          "line": 4,
+                                          "column": 21
+                                        },
+                                        "end": {
+                                          "line": 4,
+                                          "column": 38
+                                        }
+                                      }
+                                    },
+                                    "operator": "===",
+                                    "right": {
+                                      "type": "Literal",
+                                      "raw": "1",
+                                      "value": 1,
+                                      "range": [
+                                        128,
+                                        129
+                                      ],
+                                      "loc": {
+                                        "start": {
+                                          "line": 4,
+                                          "column": 43
+                                        },
+                                        "end": {
+                                          "line": 4,
+                                          "column": 44
+                                        }
+                                      }
+                                    },
+                                    "range": [
+                                      106,
+                                      129
+                                    ],
+                                    "loc": {
+                                      "start": {
+                                        "line": 4,
+                                        "column": 21
+                                      },
+                                      "end": {
+                                        "line": 4,
+                                        "column": 44
+                                      }
+                                    }
+                                  },
+                                  "shorthand": false,
+                                  "range": [
+                                    93,
+                                    130
+                                  ],
+                                  "loc": {
+                                    "start": {
+                                      "line": 4,
+                                      "column": 8
+                                    },
+                                    "end": {
+                                      "line": 4,
+                                      "column": 45
+                                    }
+                                  }
+                                }
+                              ],
+                              "selfClosing": false,
+                              "range": [
+                                88,
+                                131
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 4,
+                                  "column": 3
+                                },
+                                "end": {
+                                  "line": 4,
+                                  "column": 46
+                                }
+                              }
+                            },
+                            "children": [],
+                            "endTag": {
+                              "type": "SvelteEndTag",
+                              "range": [
+                                131,
+                                137
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 4,
+                                  "column": 46
+                                },
+                                "end": {
+                                  "line": 4,
+                                  "column": 52
+                                }
+                              }
+                            },
+                            "range": [
+                              88,
+                              137
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 4,
+                                "column": 3
+                              },
+                              "end": {
+                                "line": 4,
+                                "column": 52
+                              }
+                            }
+                          }
+                        ],
+                        "else": null,
+                        "range": [
+                          57,
+                          147
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 2
+                          },
+                          "end": {
+                            "line": 5,
+                            "column": 9
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "references": [
+                    {
+                      "identifier": {
+                        "type": "Identifier",
+                        "name": "file",
+                        "range": [
+                          114,
+                          118
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 4,
+                            "column": 29
+                          },
+                          "end": {
+                            "line": 4,
+                            "column": 33
+                          }
+                        }
+                      },
+                      "from": "function",
+                      "init": null,
+                      "resolved": {
+                        "type": "Identifier",
+                        "name": "file",
+                        "range": [
+                          79,
+                          83
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 24
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 28
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "references": [
+                {
+                  "identifier": {
+                    "type": "Identifier",
+                    "name": "rank",
+                    "range": [
+                      107,
+                      111
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 22
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 26
+                      }
+                    }
+                  },
+                  "from": "function",
+                  "init": null,
+                  "resolved": {
+                    "type": "Identifier",
+                    "name": "rank",
+                    "range": [
+                      49,
+                      53
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 23
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 27
+                      }
+                    }
+                  }
+                },
+                {
+                  "identifier": {
+                    "type": "Identifier",
+                    "name": "file",
+                    "range": [
+                      114,
+                      118
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 29
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 33
+                      }
+                    }
+                  },
+                  "from": "function",
+                  "init": null,
+                  "resolved": {
+                    "type": "Identifier",
+                    "name": "file",
+                    "range": [
+                      79,
+                      83
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 24
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 28
+                      }
+                    }
+                  }
+                }
+              ],
+              "childScopes": [],
+              "through": [
+                {
+                  "identifier": {
+                    "type": "Identifier",
+                    "name": "rank",
+                    "range": [
+                      107,
+                      111
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 22
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 26
+                      }
+                    }
+                  },
+                  "from": "function",
+                  "init": null,
+                  "resolved": {
+                    "type": "Identifier",
+                    "name": "rank",
+                    "range": [
+                      49,
+                      53
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 23
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 27
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "through": []
+        }
+      ],
+      "through": []
+    }
+  ],
+  "through": []
+}


### PR DESCRIPTION

See also https://github.com/sveltejs/svelte/releases/tag/svelte%405.4.0 and https://svelte.dev/docs/svelte/each#Each-blocks-without-an-item