### PR TITLE
feat: Add `warningFilter` to `SvelteConfig`

### DIFF
--- a/.changeset/smart-rats-decide.md
+++ b/.changeset/smart-rats-decide.md
@@ -1,0 +1,5 @@
+---
+"svelte-eslint-parser": minor
+---
+
+feat: Add `warningFilter` to `SvelteConfig`

--- a/src/svelte-config/index.ts
+++ b/src/svelte-config/index.ts
@@ -13,6 +13,7 @@ export type SvelteConfig = {
     warning: Compiler.Warning,
     defaultHandler: (warning: Compiler.Warning) => void,
   ) => void;
+  warningFilter?: (warning: Compiler.Warning) => boolean;
   [key: string]: unknown;
 };
 


### PR DESCRIPTION
Part of https://github.com/sveltejs/eslint-plugin-svelte/issues/905

Svelte5 added `warningFilter` to filter warnings as universal way.

https://svelte.dev/docs/svelte/svelte-compiler#ModuleCompileOptions