### PR TITLE
fix: do not throw error if `<script>` exists inside `{@html}`

### DIFF
--- a/.changeset/sharp-guests-sniff.md
+++ b/.changeset/sharp-guests-sniff.md
@@ -1,0 +1,5 @@
+---
+"svelte-eslint-parser": patch
+---
+
+fix: prevent errors when `<script>` tags are used inside `{@html}`

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -383,6 +383,14 @@ type SelfClosingBlock = {
   startTagRange: [number, number];
 };
 
+function isValidStartTagOpenIndex(
+  code: string,
+  startTagOpenIndex: number,
+): boolean {
+  const prev = code.slice(0, startTagOpenIndex);
+  return />\s*$|^\s*$/m.test(prev);
+}
+
 /** Extract <script> blocks */
 function* extractBlocks(code: string): IterableIterator<Block> {
   const startTagOpenRe = /<!--[\s\S]*?-->|<(script|style|template)([\s>])/giu;
@@ -396,6 +404,10 @@ function* extractBlocks(code: string): IterableIterator<Block> {
       continue;
     }
     const startTagStart = startTagOpenMatch.index;
+    if (!isValidStartTagOpenIndex(code, startTagStart)) {
+      continue;
+    }
+
     let startTagEnd = startTagOpenRe.lastIndex;
 
     const lowerTag = tag.toLowerCase() as "script" | "style" | "template";

--- a/tests/fixtures/parser/ast/at-html01-input.svelte
+++ b/tests/fixtures/parser/ast/at-html01-input.svelte
@@ -1,0 +1,1 @@
+{@html `<script>var x = ${50}</script>`}

--- a/tests/fixtures/parser/ast/at-html01-output.json
+++ b/tests/fixtures/parser/ast/at-html01-output.json
@@ -1,0 +1,233 @@
+{
+  "type": "Program",
+  "body": [
+    {
+      "type": "SvelteMustacheTag",
+      "kind": "raw",
+      "expression": {
+        "type": "TemplateLiteral",
+        "expressions": [
+          {
+            "type": "Literal",
+            "raw": "50",
+            "value": 50,
+            "range": [
+              26,
+              28
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 26
+              },
+              "end": {
+                "line": 1,
+                "column": 28
+              }
+            }
+          }
+        ],
+        "quasis": [
+          {
+            "type": "TemplateElement",
+            "tail": false,
+            "value": {
+              "cooked": "<script>var x = ",
+              "raw": "<script>var x = "
+            },
+            "range": [
+              7,
+              26
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 7
+              },
+              "end": {
+                "line": 1,
+                "column": 26
+              }
+            }
+          },
+          {
+            "type": "TemplateElement",
+            "tail": true,
+            "value": {
+              "cooked": "</script>",
+              "raw": "</script>"
+            },
+            "range": [
+              28,
+              39
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 28
+              },
+              "end": {
+                "line": 1,
+                "column": 39
+              }
+            }
+          }
+        ],
+        "range": [
+          7,
+          39
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 7
+          },
+          "end": {
+            "line": 1,
+            "column": 39
+          }
+        }
+      },
+      "range": [
+        0,
+        40
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 40
+        }
+      }
+    }
+  ],
+  "sourceType": "module",
+  "comments": [],
+  "tokens": [
+    {
+      "type": "Punctuator",
+      "value": "{",
+      "range": [
+        0,
+        1
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": "MustacheKeyword",
+      "value": "@html",
+      "range": [
+        1,
+        6
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 1,
+          "column": 6
+        }
+      }
+    },
+    {
+      "type": "Template",
+      "value": "`<script>var x = ${",
+      "range": [
+        7,
+        26
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 7
+        },
+        "end": {
+          "line": 1,
+          "column": 26
+        }
+      }
+    },
+    {
+      "type": "Numeric",
+      "value": "50",
+      "range": [
+        26,
+        28
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 26
+        },
+        "end": {
+          "line": 1,
+          "column": 28
+        }
+      }
+    },
+    {
+      "type": "Template",
+      "value": "}</script>`",
+      "range": [
+        28,
+        39
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 28
+        },
+        "end": {
+          "line": 1,
+          "column": 39
+        }
+      }
+    },
+    {
+      "type": "Punctuator",
+      "value": "}",
+      "range": [
+        39,
+        40
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 39
+        },
+        "end": {
+          "line": 1,
+          "column": 40
+        }
+      }
+    }
+  ],
+  "range": [
+    0,
+    41
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 0
+    }
+  }
+}

--- a/tests/fixtures/parser/ast/at-html01-scope-output.json
+++ b/tests/fixtures/parser/ast/at-html01-scope-output.json
@@ -1,0 +1,34 @@
+{
+  "type": "global",
+  "variables": [
+    {
+      "name": "$$slots",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$props",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    },
+    {
+      "name": "$$restProps",
+      "identifiers": [],
+      "defs": [],
+      "references": []
+    }
+  ],
+  "references": [],
+  "childScopes": [
+    {
+      "type": "module",
+      "variables": [],
+      "references": [],
+      "childScopes": [],
+      "through": []
+    }
+  ],
+  "through": []
+}


### PR DESCRIPTION
close: https://github.com/sveltejs/svelte-eslint-parser/issues/631