### PR TITLE
fix: correct detection of runes mode in parsed files

### DIFF
--- a/.changeset/brown-owls-bow.md
+++ b/.changeset/brown-owls-bow.md
@@ -1,0 +1,5 @@
+---
+"svelte-eslint-parser": patch
+---
+
+fix: correct detection of runes mode in parsed files

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -50,6 +50,7 @@ import type { NormalizedParserOptions } from "./parser-options.js";
 import { isTypeScript, normalizeParserOptions } from "./parser-options.js";
 import { getFragmentFromRoot } from "./compat.js";
 import {
+  hasRunesSymbol,
   resolveSvelteParseContextForSvelte,
   resolveSvelteParseContextForSvelteScript,
   type SvelteParseContext,
@@ -142,6 +143,7 @@ function parseAsSvelte(
     ctx,
     parserOptions,
   );
+
   const svelteParseContext = resolveSvelteParseContextForSvelte(
     svelteConfig,
     parserOptions,
@@ -161,6 +163,7 @@ function parseAsSvelte(
         scripts.attrs,
         parserOptions,
       );
+
   ctx.scriptLet.restore(resultScript);
   ctx.tokens.push(...resultScript.ast.tokens);
   ctx.comments.push(...resultScript.ast.comments);
@@ -254,7 +257,10 @@ function parseAsSvelte(
     styleNodeLoc,
     styleNodeRange,
     styleSelectorNodeLoc,
-    svelteParseContext,
+    svelteParseContext: {
+      ...svelteParseContext,
+      runes: svelteParseContext.runes ?? hasRunesSymbol(resultScript.ast),
+    },
   });
   resultScript.visitorKeys = Object.assign({}, KEYS, resultScript.visitorKeys);
 

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -259,6 +259,7 @@ function parseAsSvelte(
     styleSelectorNodeLoc,
     svelteParseContext: {
       ...svelteParseContext,
+      // The compiler decides if runes mode is used after parsing.
       runes: svelteParseContext.runes ?? hasRunesSymbol(resultScript.ast),
     },
   });

--- a/src/parser/svelte-parse-context.ts
+++ b/src/parser/svelte-parse-context.ts
@@ -5,6 +5,7 @@ import type { NormalizedParserOptions } from "./parser-options.js";
 import { compilerVersion, svelteVersion } from "./svelte-version.js";
 import type { SvelteConfig } from "../svelte-config/index.js";
 import { traverseNodes } from "../traverse.js";
+import type { ESLintProgram } from "./index.js";
 
 const runeSymbols: string[] = [
   "$state",
@@ -23,7 +24,7 @@ export type SvelteParseContext = {
    * May be `true` if the user is using Svelte v5.
    * Resolved from `svelte.config.js` or `parserOptions`, but may be overridden by `<svelte:options>`.
    */
-  runes: boolean;
+  runes?: boolean;
   /** The version of "svelte/compiler". */
   compilerVersion: string;
   /** The result of static analysis of `svelte.config.js`. */
@@ -36,7 +37,7 @@ export function resolveSvelteParseContextForSvelte(
   svelteAst: Compiler.Root | SvAST.AstLegacy,
 ): SvelteParseContext {
   return {
-    runes: isRunes(svelteConfig, parserOptions, svelteAst),
+    runes: isRunesAsParseContext(svelteConfig, parserOptions, svelteAst),
     compilerVersion,
     svelteConfig,
   };
@@ -53,11 +54,11 @@ export function resolveSvelteParseContextForSvelteScript(
   };
 }
 
-function isRunes(
+function isRunesAsParseContext(
   svelteConfig: SvelteConfig | null,
   parserOptions: NormalizedParserOptions,
   svelteAst: Compiler.Root | SvAST.AstLegacy,
-): boolean {
+): boolean | undefined {
   // Svelte 3/4 does not support Runes mode.
   if (!svelteVersion.gte(5)) {
     return false;
@@ -77,17 +78,12 @@ function isRunes(
     return svelteOptions?.runes;
   }
 
-  // Static analysis.
-  const { module, instance } = svelteAst;
-  return (
-    (module != null && hasRuneSymbol(module)) ||
-    (instance != null && hasRuneSymbol(instance))
-  );
+  return undefined;
 }
 
-function hasRuneSymbol(ast: Compiler.Script | SvAST.Script): boolean {
+export function hasRunesSymbol(ast: ESLintProgram): boolean {
   let hasRuneSymbol = false;
-  traverseNodes(ast as unknown as ESTree.Node, {
+  traverseNodes(ast, {
     enterNode(node) {
       if (hasRuneSymbol) {
         return;

--- a/src/parser/svelte-parse-context.ts
+++ b/src/parser/svelte-parse-context.ts
@@ -1,6 +1,5 @@
 import type * as Compiler from "./svelte-ast-types-for-v5.js";
 import type * as SvAST from "./svelte-ast-types.js";
-import type * as ESTree from "estree";
 import type { NormalizedParserOptions } from "./parser-options.js";
 import { compilerVersion, svelteVersion } from "./svelte-version.js";
 import type { SvelteConfig } from "../svelte-config/index.js";

--- a/src/parser/svelte-parse-context.ts
+++ b/src/parser/svelte-parse-context.ts
@@ -19,9 +19,14 @@ const runeSymbols: string[] = [
 /** The context for parsing. */
 export type SvelteParseContext = {
   /**
-   * Whether to use Runes mode.
-   * May be `true` if the user is using Svelte v5.
-   * Resolved from `svelte.config.js` or `parserOptions`, but may be overridden by `<svelte:options>`.
+   * Determines if the file is in Runes mode.
+   *
+   * - Svelte 3/4 does not support Runes mode.
+   * - Checks if `runes` configuration exists in:
+   *   - `parserOptions`
+   *   - `svelte.config.js`
+   *   - `<svelte:options>` in the Svelte file.
+   * - Returns `true` if the `runes` symbol is present in the Svelte file.
    */
   runes?: boolean;
   /** The version of "svelte/compiler". */


### PR DESCRIPTION
This PR corrects the approach used in #633, where static analysis relied on the AST of the template section to detect runes, which was entirely unnecessary. The new implementation performs static analysis on the final AST instead.