### PR TITLE
fix: align required Node version with ESLint

### DIFF
--- a/.changeset/whole-sites-juggle.md
+++ b/.changeset/whole-sites-juggle.md
@@ -1,0 +1,5 @@
+---
+"svelte-eslint-parser": patch
+---
+
+fix: align required Node version with ESLint

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "packageManager": "pnpm@9.15.6",
   "engines": {
-    "node": "^18.20.4 || ^20.18.0 || >=22.10.0"
+    "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
   },
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
close: https://github.com/sveltejs/eslint-plugin-svelte/issues/1114