### PR TITLE
perf: iterate children using a for loop

### DIFF
--- a/src/parser/converts/block.ts
+++ b/src/parser/converts/block.ts
@@ -147,17 +147,17 @@ export function convertIfBlock(
   });
   const consequent = getConsequentFromIfBlock(node);
 
-  ifBlock.children.push(
-    ...convertChildren(
-      {
-        nodes:
-          // Adjust for Svelte v5
-          trimChildren(getChildren(consequent)),
-      },
-      ifBlock,
-      ctx,
-    ),
-  );
+  for (const child of convertChildren(
+    {
+      nodes:
+        // Adjust for Svelte v5
+        trimChildren(getChildren(consequent)),
+    },
+    ifBlock,
+    ctx,
+  )) {
+    ifBlock.children.push(child);
+  }
 
   ctx.scriptLet.closeScope();
   if (elseif) {
@@ -218,17 +218,17 @@ export function convertIfBlock(
   ifBlock.else = elseBlock;
 
   ctx.scriptLet.nestBlock(elseBlock);
-  elseBlock.children.push(
-    ...convertChildren(
-      {
-        nodes:
-          // Adjust for Svelte v5
-          trimChildren(elseChildren),
-      },
-      elseBlock,
-      ctx,
-    ),
-  );
+  for (const child of convertChildren(
+    {
+      nodes:
+        // Adjust for Svelte v5
+        trimChildren(elseChildren),
+    },
+    elseBlock,
+    ctx,
+  )) {
+    elseBlock.children.push(child);
+  }
   ctx.scriptLet.closeScope();
   extractMustacheBlockTokens(elseBlock, ctx, { startOnly: true });
 


### PR DESCRIPTION
Spread is slower here than iterating through the converted children and pushing them individually.

Additionally, spreading the args can result in a large number of params which can cause other problems (sometimes `push` will throw).

I suspect the for loop is faster because `...convertChildren(...)` has to iterate the full set in order to allocate it to an array in memory, which it then has to iterate to spread as params. Whereas iterating through one at a time means we can add the child to the block without waiting for the entire iterable to finish.

i could be wrong, though. either way this fixes the rare edge case where you can try spread too many args to `push`