### PR TITLE
chore: drop require in benchmark

### DIFF
--- a/benchmark/index.ts
+++ b/benchmark/index.ts
@@ -1,10 +1,10 @@
 // eslint-disable-next-line @eslint-community/eslint-comments/disable-enable-pair -- ignore
 /* eslint-disable no-console -- ignore */
 import Benchmark from "benchmark";
-import fs from "fs";
-import { parseForESLint } from "../src/index.js";
-import { parseForESLint as parseOld } from "../node_modules/svelte-eslint-parser/lib/index.js";
+import fs from "node:fs";
 import { fileURLToPath } from "node:url";
+import { parseForESLint as parseOld } from "../node_modules/svelte-eslint-parser/lib/index.js";
+import { parseForESLint } from "../src/index.js";
 
 const contents = `${fs.readFileSync(
   fileURLToPath(

--- a/benchmark/index.ts
+++ b/benchmark/index.ts
@@ -5,11 +5,11 @@ import fs from "fs";
 import { parseForESLint } from "../src/index.js";
 import { parseForESLint as parseOld } from "../node_modules/svelte-eslint-parser/lib/index.js";
 import { fileURLToPath } from "node:url";
-import path from "node:path";
 
-const dirname = fileURLToPath(new URL(".", import.meta.url));
 const contents = `${fs.readFileSync(
-  path.resolve(dirname, "../explorer-v2/src/lib/RulesSettings.svelte"),
+  fileURLToPath(
+    import.meta.resolve("../explorer-v2/src/lib/RulesSettings.svelte"),
+  ),
   "utf-8",
 )}// comments`;
 

--- a/benchmark/index.ts
+++ b/benchmark/index.ts
@@ -1,12 +1,15 @@
 // eslint-disable-next-line @eslint-community/eslint-comments/disable-enable-pair -- ignore
 /* eslint-disable no-console -- ignore */
-import * as Benchmark from "benchmark";
+import Benchmark from "benchmark";
 import fs from "fs";
 import { parseForESLint } from "../src/index.js";
 import { parseForESLint as parseOld } from "../node_modules/svelte-eslint-parser/lib/index.js";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 
+const dirname = fileURLToPath(new URL(".", import.meta.url));
 const contents = `${fs.readFileSync(
-  require.resolve("../explorer-v2/src/lib/RulesSettings.svelte"),
+  path.resolve(dirname, "../explorer-v2/src/lib/RulesSettings.svelte"),
   "utf-8",
 )}// comments`;
 


### PR DESCRIPTION
In latest node, tsx/node seem to load this benchmark file as ESM which results in an error when trying to use `require.resolve`.

We can achieve the same with regular path resolution, using `import.meta` to get hold of the current path.